### PR TITLE
Add the NPM package-lock.json file to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ npm-debug.log*
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# This project uses Yarn mostly so ignore the regular NPM lock file
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "build/dist/components"
   ],
   "jest": {
-    "collectCoverageFrom": ["src/components/**/*.{js,jsx,ts,tsx}", "!src/components/**/index.{ts,tsx}"]
+    "collectCoverageFrom": [
+      "src/components/**/*.{js,jsx,ts,tsx}",
+      "!src/components/**/index.{ts,tsx}"
+    ]
   }
 }


### PR DESCRIPTION
Added NPM's package-lock.json file to `.gitignore` since we are primarily using Yarn for this project.  This is to make it so if someone uses NPM instead they will not commit the file to the project by mistake.