### PR TITLE
Added non-component samples

### DIFF
--- a/src/docs/border.md
+++ b/src/docs/border.md
@@ -1,0 +1,9 @@
+### Examples
+```jsx
+<Container border="top" padding="xs" margin={{ bottom: 'sm' }}>Border Top</Container>
+<Container border="right" padding="xs" margin={{ bottom: 'sm' }}>Border Right</Container>
+<Container border="bottom" padding="xs" margin={{ bottom: 'sm' }}>Border Bottom</Container>
+<Container border="left" padding="xs" margin={{ bottom: 'sm' }}>Border Left</Container>
+<Container border="all" padding="xs" margin={{ bottom: 'sm' }}>Border All</Container>
+<Container border="radius" padding="xs" margin={{ bottom: 'sm' }}>Border Radius</Container>
+```

--- a/src/docs/display.md
+++ b/src/docs/display.md
@@ -1,0 +1,15 @@
+### Screen Reader Only
+```jsx
+    <h1>This text is visible <span className="rvt-sr-only">but, this text is visually hidden and still accessible to screen readers.</span></h1>
+```
+
+### Display Property Utilities
+```jsx
+<Container display="inline" padding="xs" className="rvt-bg-midnight">Display Inline</Container>
+<Container display="block" padding="xs" margin={{ top: 'sm' }} className="rvt-bg-midnight">Display Block</Container>
+<Container display="flex" padding="xs" margin={{ top: 'sm' }} className="rvt-bg-midnight">
+    <div className="rvt-bg-blue rvt-m-right-sm rvt-p-all-xs">Flex Child</div>
+    <div className="rvt-bg-blue rvt-m-right-sm rvt-p-all-xs">Flex Child</div>
+    <div className="rvt-bg-blue rvt-m-right-sm rvt-p-all-xs">Flex Child</div>
+</Container>
+```

--- a/src/docs/links.md
+++ b/src/docs/links.md
@@ -1,0 +1,5 @@
+### Example
+```jsx
+<p className="rvt-m-top-remove">This is a <a href="#">text link</a> on a light background.</p>
+<p className="bg-midnight rvt-p-all-sm">This is a <a href="#">text link</a> on a dark background.</p>
+```

--- a/src/docs/spacing.md
+++ b/src/docs/spacing.md
@@ -1,0 +1,30 @@
+### Examples
+```jsx
+<Container padding="xxs" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">xxs</div>
+</Container>
+<Container padding="xs" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">xs</div>
+</Container>
+<Container padding="sm" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">sm</div>
+</Container>
+<Container padding="md" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">md</div>
+</Container>
+<Container padding="lg" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">lg</div>
+</Container>
+<Container padding="xl" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">xl</div>
+</Container>
+<Container padding="xxl" margin={{ bottom: 'sm' }} className="rvt-bg-blue rvt-text-center">
+    <div className="rvt-bg-midnight">xxl</div>
+</Container>
+```
+
+### Responsive Spacing
+**Coming soon**
+
+### No spacing
+**Coming soon**

--- a/src/docs/text-utils.md
+++ b/src/docs/text-utils.md
@@ -1,0 +1,22 @@
+### Font Weght
+```jsx
+<strong className="rvt-text-regular">Regular text utilitiy</strong>
+<div className="rvt-text-bold">Bold Text utility</div>
+```
+
+### Line Height
+```jsx
+<h3 className="rvt-ts-36 rvt-lh-title">This large text could sometimes end up in a space that causes it to run on to two lines.</h3>
+```
+
+### Text Alignment
+```jsx
+<p className="rvt-text-left">Left-aligned text utilitiy</p>
+<p className="rvt-text-center">Center-aligned text utilitiy</p>
+<p className="rvt-text-right">Right-aligned text utilitiy</p>
+```
+
+### Uppercase
+```jsx
+<p className="rvt-text-uppercase">Uppercase text utilitiy</p>
+```

--- a/src/docs/typography.md
+++ b/src/docs/typography.md
@@ -1,0 +1,29 @@
+### Examples
+```jsx
+<Container typescale={12}>Fulfilling the Promise (12, xxs)</Container>
+<Container typescale={14}>Fulfilling the Promise (14, xs)</Container>
+<Container typescale={16}>Fulfilling the Promise (16, Base, sm)</Container>
+<Container typescale={18}>Fulfilling the Promise (18, md)</Container>
+<Container typescale={20}>Fulfilling the Promise (20, lg)</Container>
+<Container typescale={23}>Fulfilling the Promise (23)</Container>
+<Container typescale={26}>Fulfilling the Promise (26, xl)</Container>
+<Container typescale={29}>Fulfilling the Promise (29)</Container>
+<Container typescale={32}>Fulfilling the Promise (32, xxl)</Container>
+<Container typescale={36}>Fulfilling the Promise (36)</Container>
+<Container typescale={41}>Fulfilling the Promise (41)</Container>
+<Container typescale={46}>Fulfilling the Promise (46)</Container>
+<Container typescale={52}>Fulfilling the Promise (52)</Container>
+```
+
+### Headings
+```jsx
+<h1>Fulfilling the Promise (h1)</h1>
+<h2>Fulfilling the Promise (h2)</h2>
+<h3>Fulfilling the Promise (h3)</h3>
+<h4>Fulfilling the Promise (h4)</h4>
+<h5>Fulfilling the Promise (h5)</h5>
+<h6>Fulfilling the Promise (h6)</h6>
+```
+
+### Responsive Typescale
+**Coming soon**

--- a/src/docs/visibility.md
+++ b/src/docs/visibility.md
@@ -1,0 +1,17 @@
+### Hide Down Responsive Utilities
+```jsx
+<Container hide="sm-down">Hidden at <strong>small breakpoint</strong> down</Container>
+<Container hide="md-down">Hidden at <strong>medium breakpoint</strong> down</Container>
+<Container hide="lg-down">Hidden at <strong>large breakpoint</strong> down</Container>
+<Container hide="xl-down">Hidden at <strong>extra large breakpoint</strong> down</Container>
+<Container hide="xxl-down">Hidden at <strong>extra extra large breakpoint</strong> down</Container>
+```
+
+### Hide Up Responsive Utilities
+```jsx
+<Container hide="sm-up">Hidden at <strong>small breakpoint</strong> up</Container>
+<Container hide="md-up">Hidden at <strong>medium breakpoint</strong> up</Container>
+<Container hide="lg-up">Hidden at <strong>large breakpoint</strong> up</Container>
+<Container hide="xl-up">Hidden at <strong>extra large breakpoint</strong> up</Container>
+<Container hide="xxl-up">Hidden at <strong>extra extra large breakpoint</strong> up</Container>
+```

--- a/src/docs/z-index.md
+++ b/src/docs/z-index.md
@@ -1,0 +1,16 @@
+### Z-Index Range
+```jsx
+<div style={{ position: 'relative', height: '35rem', width: '100%' }}>
+    <div className="rvt-z-1000 rvt-p-all-sm rvt-bg-cream rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: 0, left: 0 }}>1000</div>
+    <div className="rvt-z-900 rvt-p-all-sm rvt-bg-gray rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '3rem', left: '3rem' }}>900</div>
+    <div className="rvt-z-800 rvt-p-all-sm rvt-text-center" style={{ backgroundColor: '#4a3c31', color: 'white', width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '6rem', left: '6rem' }}>800</div>
+    <div className="rvt-z-700 rvt-p-all-sm rvt-text-center" style={{ backgroundColor: '#66435a', color: 'white', width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '9rem', left: '9rem' }}>700</div>
+    <div className="rvt-z-600 rvt-p-all-sm rvt-bg-dark-midnight rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '12rem', left: '12rem' }}>600</div>
+    <div className="rvt-z-500 rvt-p-all-sm rvt-bg-midnight rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '15rem', left: '15rem' }}>500</div>
+    <div className="rvt-z-400 rvt-p-all-sm rvt-bg-blue rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '18rem', left: '18rem' }}>400</div>
+    <div className="rvt-z-300 rvt-p-all-sm rvt-bg-green rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '21rem', left: '21rem' }}>300</div>
+    <div className="rvt-z-200 rvt-p-all-sm rvt-bg-yellow rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '24rem', left: '24rem' }}>200</div>
+    <div className="rvt-z-100 rvt-p-all-sm rvt-bg-orange rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '27rem', left: '27rem' }}>100</div>
+    <div className="rvt-z-0 rvt-p-all-sm rvt-bg-crimson rvt-text-center" style={{ width: '80px', height: '80px', lineHeight: '48px', position: 'absolute', top: '30rem', left: '30rem' }}>0</div>
+</div>
+```

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -6,8 +6,12 @@ module.exports = {
     resolver: require('react-docgen').resolver.findAllComponentDefinitions,
     propsParser: require('react-docgen-typescript').withDefaultConfig({
         propFilter: (prop, component) => 
-            prop.description.length > 0               // skip props with no documentation
-            && prop.name.includes("aria-") === false  // skip aria props
+            // skip props with no documentation
+            prop.description.length > 0
+            // skip aria props               
+            && prop.name.includes("aria-") === false
+            // skip 'rivetize' props (these are documented separately)
+            && ['className','border','display','hide','margin','padding','typescale'].indexOf(prop.name) === -1  
     }).parse,
     pagePerSection: true,
     sections: [

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -9,6 +9,7 @@ module.exports = {
             prop.description.length > 0               // skip props with no documentation
             && prop.name.includes("aria-") === false  // skip aria props
     }).parse,
+    pagePerSection: true,
     sections: [
         {
             name: 'Introduction',
@@ -19,6 +20,13 @@ module.exports = {
             components: () => [
               'src/components/Badge/*.tsx', 
               'src/components/List/*.tsx', 
+            ],
+            sections: [
+                {
+                    name: 'Links',
+                    content: 'src/docs/links.md',
+                    exampleMode: 'expand'
+                }
             ],
             exampleMode: 'expand'
         },
@@ -37,9 +45,27 @@ module.exports = {
         },
         {
             name: 'Layout',
+            sections: [
+                {
+                    name: 'Grid',
+                    components: () => [
+                      'src/components/Grid/*.tsx',
+                    ],
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'Spacing',
+                    content: 'src/docs/spacing.md',
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'Typography',
+                    content: 'src/docs/typography.md',
+                    exampleMode: 'expand'
+                }
+            ],
             components: () => [
-              'src/components/Grid/*.tsx',
-              'src/components/Section/*.tsx',
+                'src/components/Section/*.tsx'
             ],
             exampleMode: 'expand'
         },
@@ -56,6 +82,36 @@ module.exports = {
               'src/components/Alert/*.tsx', 
             ],
             exampleMode: 'expand'
+        },
+        {
+            name: 'Utilities',
+            sections: [
+                {
+                    name: 'Border',
+                    content: 'src/docs/border.md',
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'Typography',
+                    content: 'src/docs/display.md',
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'Text',
+                    content: 'src/docs/text-utils.md',
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'Visibility',
+                    content: 'src/docs/visibility.md',
+                    exampleMode: 'expand'
+                },
+                {
+                    name: 'z-index',
+                    content: 'src/docs/z-index.md',
+                    exampleMode: 'expand'
+                }
+            ]
         },
     ],
     webpackConfig: require('react-scripts-ts/config/webpack.config.dev'),

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -69,7 +69,6 @@ module.exports = {
                 }
             ],
             components: () => [
-              'src/components/Section/*.tsx'
               'src/components/Panel/*.tsx',
               'src/components/Section/*.tsx',
             ],


### PR DESCRIPTION
Added documentation with more samples from the Rivet pages to fill in some examples of how to use Rivet utilities and other styling with the React components.

This also changes the style guide so it creates a page per section since it was starting to get fairly lengthy.