### PR TITLE
Rename the role property to modifier

### DIFF
--- a/src/components/Badge/Badge.md
+++ b/src/components/Badge/Badge.md
@@ -9,9 +9,9 @@
 
 ### Secondary Badges
 ```jsx
-<Badge role="secondary">Base</Badge>{' '}
-<Badge variant="action" role="secondary">Action</Badge>{' '}
-<Badge variant="success" role="secondary">Success</Badge>{' '}
-<Badge variant="warning" role="secondary">Warning</Badge>{' '}
-<Badge variant="error" role="secondary">Error</Badge>
+<Badge modifier="secondary">Base</Badge>{' '}
+<Badge variant="action" modifier="secondary">Action</Badge>{' '}
+<Badge variant="success" modifier="secondary">Success</Badge>{' '}
+<Badge variant="warning" modifier="secondary">Warning</Badge>{' '}
+<Badge variant="error" modifier="secondary">Error</Badge>
 ```

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -21,11 +21,11 @@ describe('<Badge />', () => {
             expect(cut.find('span').hasClass('rvt-badge--action')).toBe(true);
         });
         it('should apply secondary role', () => {
-            const cut = mount(<Badge role="secondary" />);
+            const cut = mount(<Badge modifier="secondary" />);
             expect(cut.find('span').hasClass('rvt-badge--secondary')).toBe(true);
         });
         it('should apply secondary variant class appropriately', () => {
-            const cut = mount(<Badge variant="action" role="secondary" />);
+            const cut = mount(<Badge variant="action" modifier="secondary" />);
             expect(cut.find('span').hasClass('rvt-badge--action')).toBe(false);
             expect(cut.find('span').hasClass('rvt-badge--secondary')).toBe(false);
             expect(cut.find('span').hasClass('rvt-badge--action-secondary')).toBe(true);

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -3,16 +3,24 @@ import * as React from 'react';
 import { rivetize } from '../util/Rivet';
 
 interface BadgeProps {
-    role?: 'default' | 'secondary',
+    /**
+     * Optional Rivet style: a secondary badge.
+     * @see https://rivet.uits.iu.edu/components/forms/buttons/#secondary-variations
+     */
+    modifier?: 'default' | 'secondary',
+    /**
+     * Optional Rivet style: a success/danger/plain badge.
+     * @see https://rivet.uits.iu.edu/components/page-content/badges/#secondary-badges
+     */
     variant?: '' | 'action' | 'error' | 'success' | 'warning';
 }
 
-const Badge : React.SFC<BadgeProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, role = 'default', variant, ...attrs }) => {
+const Badge : React.SFC<BadgeProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, modifier = 'default', variant, ...attrs }) => {
     const classes = classNames({
         ['rvt-badge']: true,
-        [`rvt-badge--${variant}-secondary`]: !!variant && role === 'secondary',
-        [`rvt-badge--${variant}`]: !!variant && role === 'default',
-        ['rvt-badge--secondary']: !variant && role === 'secondary'
+        [`rvt-badge--${variant}-secondary`]: !!variant && modifier === 'secondary',
+        [`rvt-badge--${variant}`]: !!variant && modifier === 'default',
+        ['rvt-badge--secondary']: !variant && modifier === 'secondary'
     }, className);
     return (
         <span className={classes} {...attrs}>{children}</span>

--- a/src/components/Button/Button.md
+++ b/src/components/Button/Button.md
@@ -9,10 +9,10 @@
 
 ### Secondary Buttons
 ```jsx
-<Button margin="xs" onClick={() => { console.log('Click!') }} role="secondary">Primary</Button>
-<Button margin="xs" onClick={() => { console.log('Click!') }} variant="success" role="secondary">Success</Button>
-<Button margin="xs" onClick={() => { console.log('Click!') }} variant="danger" role="secondary">Danger</Button>
-<Button margin="xs" onClick={() => { console.log('Click!') }} disabled role="secondary">Disabled</Button>
+<Button margin="xs" onClick={() => { console.log('Click!') }} modifier="secondary">Primary</Button>
+<Button margin="xs" onClick={() => { console.log('Click!') }} variant="success" modifier="secondary">Success</Button>
+<Button margin="xs" onClick={() => { console.log('Click!') }} variant="danger" modifier="secondary">Danger</Button>
+<Button margin="xs" onClick={() => { console.log('Click!') }} disabled modifier="secondary">Disabled</Button>
 ```
 
 ### Small Buttons

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -41,19 +41,19 @@ describe('<Button />', () => {
 
         // Secondary variations
         it('should have secondary role', () => {
-            const cut = mount(<Button role="secondary" />);
+            const cut = mount(<Button modifier="secondary" />);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--secondary")).toEqual(true);
         });
         it('should have secondary success style', () => {
-            const cut = mount(<Button role="secondary" variant="success" />);
+            const cut = mount(<Button modifier="secondary" variant="success" />);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--success-secondary")).toEqual(true);
         });
         it('should have secondary danger style', () => {
-            const cut = mount(<Button role="secondary" variant="danger" />);
+            const cut = mount(<Button modifier="secondary" variant="danger" />);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--danger-secondary")).toEqual(true);
         });
         it('should have secondary plain style', () => {
-            const cut = mount(<Button role="secondary" variant="plain" />);
+            const cut = mount(<Button modifier="secondary" variant="plain" />);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--plain-secondary")).toEqual(true);
         });
         
@@ -69,7 +69,7 @@ describe('<Button />', () => {
 
         // All together now!
         it('should have a secondary small size', () => {
-            const cut = mount(<Button size="small" role="secondary" variant="plain" />);
+            const cut = mount(<Button size="small" modifier="secondary" variant="plain" />);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--plain-secondary")).toEqual(true);
             expect(cut.find('button.rvt-button').hasClass("rvt-button--small")).toEqual(true);
         });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -7,31 +7,31 @@ import * as Rivet from '../util/Rivet';
  */
 type VariantType = 'success' | 'danger' | 'plain' | 'default' | 'navigation';
 type SizeType = 'small' | 'default';
-type RoleType = 'secondary' | 'default';
+type ModifierType = 'secondary' | 'default';
 export interface ButtonProps {
     /** Optional Rivet style: a success/danger/plain button. The 'navigation' variant is intended to support the Header component only. See: https://rivet.uits.iu.edu/components/forms/buttons/#button-examples */
     variant?: VariantType;
     /** Optional Rivet style: a small button. See: https://rivet.uits.iu.edu/components/forms/buttons/#small-buttons */
     size?: SizeType;
     /** Optional Rivet style: a secondary button. See: https://rivet.uits.iu.edu/components/forms/buttons/#secondary-variations */
-    role?: RoleType;
+    modifier?: ModifierType;
     innerRef?: React.Ref<HTMLButtonElement>;
 }
 
 const None = '';
 const buttonClass = 'rvt-button';
 /**
- * Generate the combined role and variation class for this button, if applicable.
+ * Generate the combined modifier and variation class for this button, if applicable.
  * @param attrs This button's properties
  * @see https://rivet.uits.iu.edu/components/forms/buttons/#secondary-variations
  */
-const buttonRoleAndStyle = (variant: VariantType, role: RoleType) => {
+const buttonModifierAndStyle = (variant: VariantType, modifier: ModifierType) => {
   if(variant === 'navigation') {
     return 'rvt-dropdown__toggle';
   }
   const classParts = [
     variant !== 'default' ? variant : None,
-    role !== 'default' ? role : None
+    modifier !== 'default' ? modifier : None
   ].filter(x => x !== None);
   // combine variation and style, if any.
   return classParts.length === 0
@@ -47,8 +47,8 @@ const buttonRoleAndStyle = (variant: VariantType, role: RoleType) => {
 const buttonSize = (size: SizeType) => (size !== "default" ? `${buttonClass}--${size}` : None);
 
 export const Button: React.SFC<ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>> = 
-  ({role = "default", size = "default", variant = "default", onClick, id = Rivet.shortuid(), innerRef, className, children, ...attrs}) => {
-  const classes = classNames(buttonRoleAndStyle(variant, role), buttonSize(size), className);
+  ({modifier = "default", size = "default", variant = "default", onClick, id = Rivet.shortuid(), innerRef, className, children, ...attrs}) => {
+  const classes = classNames(buttonModifierAndStyle(variant, modifier), buttonSize(size), className);
   return (
     <button
       id={id}

--- a/src/components/Button/ButtonGroup.md
+++ b/src/components/Button/ButtonGroup.md
@@ -2,6 +2,6 @@
 ```jsx
 <ButtonGroup>
     <Button onClick={() => { console.log('Click!') }}>OK</Button>
-    <Button onClick={() => { console.log('Click!') }} role="secondary">Cancel</Button>
+    <Button onClick={() => { console.log('Click!') }} modifier="secondary">Cancel</Button>
 </ButtonGroup>
 ```


### PR DESCRIPTION
Renames the role property on Badge and Button to be named modifier instead to avoid collision with the ARIA role attribute.

Fixes #79