### PR TITLE
Remove the default option from several enum types

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -7,19 +7,19 @@ interface BadgeProps {
      * Optional Rivet style: a secondary badge.
      * @see https://rivet.uits.iu.edu/components/forms/buttons/#secondary-variations
      */
-    modifier?: 'default' | 'secondary',
+    modifier?: 'secondary',
     /**
      * Optional Rivet style: a success/danger/plain badge.
      * @see https://rivet.uits.iu.edu/components/page-content/badges/#secondary-badges
      */
-    variant?: '' | 'action' | 'error' | 'success' | 'warning';
+    variant?: 'action' | 'error' | 'success' | 'warning';
 }
 
-const Badge : React.SFC<BadgeProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, modifier = 'default', variant, ...attrs }) => {
+const Badge : React.SFC<BadgeProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, modifier, variant, ...attrs }) => {
     const classes = classNames({
         ['rvt-badge']: true,
         [`rvt-badge--${variant}-secondary`]: !!variant && modifier === 'secondary',
-        [`rvt-badge--${variant}`]: !!variant && modifier === 'default',
+        [`rvt-badge--${variant}`]: !!variant && modifier === undefined,
         ['rvt-badge--secondary']: !variant && modifier === 'secondary'
     }, className);
     return (

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -5,9 +5,9 @@ import * as Rivet from '../util/Rivet';
 /**
  * The properties of a button.
  */
-type VariantType = 'success' | 'danger' | 'plain' | 'default' | 'navigation';
-type SizeType = 'small' | 'default';
-type ModifierType = 'secondary' | 'default';
+type VariantType = 'success' | 'danger' | 'plain' | 'navigation';
+type SizeType = 'small';
+type ModifierType = 'secondary';
 export interface ButtonProps {
     /** Optional Rivet style: a success/danger/plain button. The 'navigation' variant is intended to support the Header component only. See: https://rivet.uits.iu.edu/components/forms/buttons/#button-examples */
     variant?: VariantType;
@@ -25,13 +25,13 @@ const buttonClass = 'rvt-button';
  * @param attrs This button's properties
  * @see https://rivet.uits.iu.edu/components/forms/buttons/#secondary-variations
  */
-const buttonModifierAndStyle = (variant: VariantType, modifier: ModifierType) => {
+const buttonModifierAndStyle = (variant?: VariantType, modifier?: ModifierType) => {
   if(variant === 'navigation') {
     return 'rvt-dropdown__toggle';
   }
   const classParts = [
-    variant !== 'default' ? variant : None,
-    modifier !== 'default' ? modifier : None
+    variant !== undefined ? variant : None,
+    modifier !== undefined ? modifier : None
   ].filter(x => x !== None);
   // combine variation and style, if any.
   return classParts.length === 0
@@ -44,10 +44,10 @@ const buttonModifierAndStyle = (variant: VariantType, modifier: ModifierType) =>
  * @param attrs This button's properties
  * @see https://rivet.uits.iu.edu/components/forms/buttons/#small-buttons
  */
-const buttonSize = (size: SizeType) => (size !== "default" ? `${buttonClass}--${size}` : None);
+const buttonSize = (size?: SizeType) => (size !== undefined ? `${buttonClass}--${size}` : None);
 
 export const Button: React.SFC<ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>> = 
-  ({modifier = "default", size = "default", variant = "default", onClick, id = Rivet.shortuid(), innerRef, className, children, ...attrs}) => {
+  ({ className, children, id = Rivet.shortuid(), innerRef, modifier, onClick, size, variant, ...attrs}) => {
   const classes = classNames(buttonModifierAndStyle(variant, modifier), buttonSize(size), className);
   return (
     <button

--- a/src/components/Input/common.tsx
+++ b/src/components/Input/common.tsx
@@ -6,7 +6,7 @@ import * as Rivet from '../util/Rivet';
 
 import { alertClass, Variant } from '../Alert/inlineAlertVariantDisplayOptions';
 
-type InputVariant = Variant | 'default';
+type InputVariant = Variant;
 export interface TextProps {
     label: string;
     note?: React.ReactNode;
@@ -17,17 +17,17 @@ export interface TextProps {
     variant?: InputVariant;
 }
 
-const isInlineAlert = (variant : InputVariant) => variant && variant !== 'default';
+const isInlineAlert = (variant?: InputVariant) => variant && variant !== undefined;
 
 const standardNote = (id : string, note : React.ReactNode) => <small id={id} className="rvt-display-block rvt-m-bottom-md">{note}</small>
 
-const inputClassName = (variant : InputVariant) => isInlineAlert(variant)
+const inputClassName = (variant?: InputVariant) => isInlineAlert(variant)
     ? `rvt-${alertClass(variant as Variant)}`
     : '';
 
 const labelFragment = (inputId : string, props : TextProps) => <label htmlFor={inputId}>{props.label}</label>
 
-const noteFragment = (id : string, variant: InputVariant, note? : React.ReactNode) => note
+const noteFragment = (id : string, variant?: InputVariant, note? : React.ReactNode) => note
     ? isInlineAlert(variant)
         ? <InlineAlert id={id} variant={variant as Variant}>{note}</InlineAlert>
         : standardNote(id, note)
@@ -37,7 +37,7 @@ type TextComponentGenerator = <T>(id:string, className: string, ariaDescribedBy:
 export const renderInput =
     <T extends React.HTMLAttributes<HTMLElement>>( props: TextProps & T, inputGenerator: TextComponentGenerator ) => {
         const inputId = props.id || Rivet.shortuid();
-        const variant = props.variant || 'default';
+        const variant = props.variant;
         const note = props.note;
         const noteId = `${inputId}_note`;
         const inputClass = inputClassName(variant);

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import * as Rivet from '../util/Rivet'
 
 type ListVariant = 'ordered' | 'plain' | 'unordered';
-type ListOrientation = 'inline' | 'default';
+type ListOrientation = 'inline';
 export interface ListProps {
     /**
      * Optional Rivet style for the type of list decoration.

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -2,7 +2,7 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 import { rivetize } from '../util/Rivet';
 
-type Variant = 'default' | 'light';
+type Variant = 'light';
 
 interface PanelProps {
 
@@ -13,10 +13,10 @@ interface PanelProps {
     variant?: Variant;
 }
 
-const Panel : React.SFC<PanelProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className,  variant='default', ...attrs }) => {
+const Panel : React.SFC<PanelProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, variant, ...attrs }) => {
     const classes = classNames({
         ['rvt-panel']: true,
-        [`rvt-panel--${variant}`]: variant !== 'default' 
+        [`rvt-panel--${variant}`]: variant !== undefined
     }, className);
     return (
         <div className={classes} {...attrs}>{children}</div>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -7,10 +7,10 @@ interface TableProps {
      * Optional Rivet style which changes the look and feel of the rendered table.
      * @see https://rivet.uits.iu.edu/components/page-content/tables/
      */
-    variant?: 'default' | 'stripes' | 'plain'
+    variant?: 'stripes' | 'plain'
 }
 
-const Table : React.SFC<TableProps & React.HTMLAttributes<HTMLTableElement>> = ({ children, className, variant = 'default', ...attrs }) => {
+const Table : React.SFC<TableProps & React.HTMLAttributes<HTMLTableElement>> = ({ children, className, variant, ...attrs }) => {
     const classes = classNames({
         ['rvt-table-plain']: variant === 'plain',
         ['rvt-table-stripes']: variant === 'stripes',


### PR DESCRIPTION
This drops the "default" option which was not intended for users to use and changes the checks to use undefined instead.