### PR TITLE
Don't publish gh-pages from develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,6 @@ aliases:
     branches:
       only:
         - master
-        - develop
   - &filter-ignore-gh-pages
     branches:
       ignore: gh-pages


### PR DESCRIPTION
Now that we've merged 0.3.0 (yay!), `master` should be the exclusive source for `gh-pages`.