### PR TITLE
Move jest-cli and react-scripts-ts to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,21 +11,19 @@
   ],
   "main": "build/dist/components/index.js",
   "types": "build/dist/components/index.d.ts",
-  "dependencies": {
-    "classnames": "2.2.6",
-    "jest-cli": "23.5.0",
-    "react": "16.4.1",
-    "react-display-name": "0.2.4",
-    "react-dom": "16.4.1",
-    "react-scripts-ts": "2.17.0",
-    "rivet-uits": "1.0.0"
-  },
   "scripts": {
     "start": "npx styleguidist server",
     "build": "rm -rf ./build/dist && tsc -p tsconfig.dist.json",
     "publish-guide": "npx styleguidist build && cp -r .circleci styleguide && gh-pages --dist styleguide --dotfiles",
     "test": "react-scripts-ts test --env=jsdom",
     "eject": "react-scripts-ts eject"
+  },
+  "dependencies": {
+    "classnames": "2.2.6",
+    "react": "16.4.1",
+    "react-display-name": "0.2.4",
+    "react-dom": "16.4.1",
+    "rivet-uits": "1.0.0"
   },
   "devDependencies": {
     "@types/classnames": "2.2.6",
@@ -39,7 +37,9 @@
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "gh-pages": "1.2.0",
+    "jest-cli": "23.5.0",
     "react-docgen-typescript": "1.7.0",
+    "react-scripts-ts": "2.17.0",
     "react-styleguidist": "7.2.5",
     "typescript": "2.9.2"
   },


### PR DESCRIPTION
These two dependencies should not be required by consumers of the library since they are used to build and test it so this change moves them to the devDependencies section of package.json.