### PR TITLE
Remove `Rivet.Action`

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -17,7 +17,7 @@ export interface ModalProps {
      * Optional function to call to raise when the alert is dismissed. If undefined, the modal will act as a dialog (i.e., no close button, 
      * will not close on outside click or escape key)
      */
-    onDismiss?: Rivet.Action;
+    onDismiss?: () => void;
     /**
      * The content of the modal's header
      */

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -13,4 +13,3 @@ export * from './Panel';
 export * from './RadioButton';
 export * from './Section';
 export * from './Table';
-export { Action } from './util/Rivet';

--- a/src/components/util/Rivet.tsx
+++ b/src/components/util/Rivet.tsx
@@ -3,8 +3,6 @@ import * as React from 'react';
 
 // Classes, Interfaces, and Types
 
-export type Action = () => void;
-
 export interface Props {
     /**
      * Optional Rivet style: type scale adjustment


### PR DESCRIPTION
We've been weeding this out over time.