### PR TITLE
fix(ci): Build components prior to publishing NPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ jobs:
     steps:
       - checkout 
       - restore_cache: *restore-node-modules
+      - run: 
+          name: Build components
+          command: yarn build
       - run:
           name: Publish package
           command: npx semantic-release


### PR DESCRIPTION
The NPM package is being published without any components. I think it's because semantic-release expects them to be built already. This PR adds a task to take care of that.