### PR TITLE
Fix display issue with sr-only label on a Checkbox

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -55,7 +55,8 @@ describe('<Checkbox />', () => {
 
   it('should hide the label for sighted displays', () => {
     const cut = mount(<Checkbox label="the_label" labelVisibility="screen-reader-only" />);
-    expect(cut.find('label').hasClass("rvt-sr-only")).toBe(true);
+    expect(cut.find('label > span').hasClass("rvt-sr-only")).toBe(true);
+    expect(cut.find('label').hasClass("rvt-sr-only")).toBe(false);
   });
 
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -17,7 +17,7 @@ const Checkbox : React.SFC<CheckboxProps & React.InputHTMLAttributes<HTMLInputEl
     <>
         <input id={id} type="checkbox" {...attrs} />
         { children }
-        <label className={Rivet.labelVisiblityClass(labelVisibility)} htmlFor={id}>{label}</label>
+        <label htmlFor={id}><span className={Rivet.labelVisiblityClass(labelVisibility)}>{label}</span></label>
     </>
 );
 Checkbox.displayName = 'Checkbox';


### PR DESCRIPTION
The "rvt-sr-only" class was being applied to the label when the label visibility was changed and that kept the entire checkbox from appearing.  This was fixed by applying the sr-only class to an inner span instead.