### PR TITLE
Add tabs support

### DIFF
--- a/src/components/Tabs/Tab.md
+++ b/src/components/Tabs/Tab.md
@@ -1,0 +1,1 @@
+The `Tab` is used within a `Tabs` container for holding the content of a single tab. See the [Tabs section](#/Page%20Content?id=tabs) for usage examples.

--- a/src/components/Tabs/Tab.test.tsx
+++ b/src/components/Tabs/Tab.test.tsx
@@ -1,0 +1,26 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+import Tab from './Tab';
+
+describe('<Tab />', () => {
+
+    describe('Rendering and text', ()=>{
+        it('should render without throwing an error', () => {
+            const cut = mount(<Tab />);
+            expect(cut.find('div.rvt-tabs__panel')).toHaveLength(1);
+        });
+        it('should take an id', () => {
+            const cut = mount(<Tab id="the_id"/>);
+            expect(cut.find('div.rvt-tabs__panel#the_id')).toHaveLength(1);
+        });
+        it('should show text children', () => {
+            const cut = mount(<Tab title="Tab">The text</Tab>);
+            expect(cut.find('div.rvt-tabs__panel').text()).toEqual('The text');
+        });
+        it('should set aria-labeledby', () => {
+            const cut = mount(<Tab id="the_id" title="Tab">The text</Tab>);
+            expect(cut.find('div.rvt-tabs__panel').prop('aria-labelledby')).toEqual('the_id-tab');
+        });
+    });
+
+});

--- a/src/components/Tabs/Tab.tsx
+++ b/src/components/Tabs/Tab.tsx
@@ -1,0 +1,17 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+
+import * as Rivet from '../util/Rivet';
+
+const Tab: React.SFC<React.HTMLAttributes<HTMLDivElement>> =
+  ({ children, className, id = Rivet.shortuid(), ...attrs }) => {
+    const classes = classNames('rvt-tabs__panel', className);
+    return (
+      <div {...attrs} className={classes} tabIndex={0} role="tabpanel" id={id} aria-labelledby={`${id}-tab`}>
+        {children}
+      </div>
+    )
+  };
+Tab.displayName = 'Tab';
+
+export default Tab;

--- a/src/components/Tabs/Tabs.md
+++ b/src/components/Tabs/Tabs.md
@@ -1,0 +1,105 @@
+Use tabs to allow users to switch between logical chunks of content without having to leave the current page.
+
+View the [Rivet documentation for Tabs](https://rivet.uits.iu.edu/components/page-content/tabs/).
+
+### Default tabs example
+
+```jsx
+<Tabs>
+  <Tab id="t-one" title="Tab one">
+    <span class="rvt-ts-23 rvt-text-bold">Panel 1</span>
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+        in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-two" title="Tab two">
+    <span class="rvt-ts-23 rvt-text-bold">Panel 2</span>
+    <p>
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-three" title="Tab three">
+    <span class="rvt-ts-23 rvt-text-bold">A grid inside a tab panel</span>
+    <Row>
+      <Col md={4}>
+        <p>
+            Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </Col>
+      <Col md={4}>
+        <p>
+            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </Col>
+    </Row>
+  </Tab>
+</Tabs>
+```
+
+### Fitted version
+
+Applying the `fitted` variant will make the tabs take up equal amounts of the space of the tabs container.
+
+```jsx
+<Tabs variant="fitted">
+  <Tab id="t-one" title="Tab one">
+    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Sue’s Salads</span>
+    <p>
+        Panel 1: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
+        irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-two" title="Tab two">
+    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
+    <p>
+        Panel 2: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-three" title="Tab three">
+    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Food n’ Stuff</span>
+    <p>
+        Panel 3: Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+</Tabs>
+```
+
+### Vertical Tabs
+
+The `vertical` variant creates a set of tabs where the tab controls display in a vertical list on the left with the tab panels on the right.
+
+```jsx
+<Tabs variant="vertical">
+  <Tab id="t-one" title="Tab one">
+    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Paunch Burger</span>
+    <p>
+        Panel 1: Lorem ipsum dolor sit amet,
+        <a href="#0">consectetur adipisicing elit</a>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
+        in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-two" title="Tab two">
+    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
+    <p>
+        Panel 2: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </p>
+  </Tab>
+  <Tab id="t-three" title="Tab three">
+    <Form label="Sue's Salads Takeout" labelVisibility="screen-reader-only">
+      <Input type="text" name="name" id="name" label="Name" />
+      <Select name="salads" id="salads" label="Salad type" margin={{top: 'md'}}>
+        <option value="">Cobb</option>
+        <option value="">Ceasar</option>
+        <option value="">Wedge</option>
+        <option value="">Big</option>
+      </Select>
+      <Textarea name="message" id="message" label="Message" margin={{top: 'md', bottom: 'md'}} />
+      <ButtonGroup right>
+        <Button type="submit" onClick={() => { console.log('Submit'); }}>Submit</Button>
+        <Button variant="plain" onClick={() => { console.log('Cancel'); }}>Cancel</Button>
+      </ButtonGroup>
+    </Form>
+  </Tab>
+</Tabs>
+```

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,57 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+import Tab from './Tab';
+import Tabs from './Tabs';
+
+describe('<Tabs />', () => {
+
+  describe('Rendering and text', () => {
+    it('should render without throwing an error', () => {
+      const cut = mount(<Tabs />);
+      expect(cut.find('div.rvt-tabs')).toHaveLength(1);
+    });
+    it('should take an id', () => {
+      const cut = mount(<Tabs id="the_id" />);
+      expect(cut.find('div.rvt-tabs#the_id')).toHaveLength(1);
+    });
+    it('should set aria-orientation', () => {
+      const cut = mount(<Tabs />);
+      expect(cut.find('div.rvt-tabs__tablist').prop('aria-orientation')).toEqual('horizontal');
+    });
+  });
+
+  describe('Styling', () => {
+    it('should have a fitted variant', () => {
+      const cut = mount(<Tabs variant="fitted" />);
+      expect(cut.find('div.rvt-tabs').hasClass('rvt-tabs--fitted')).toBe(true);
+    });
+    it('should have a vertical variant', () => {
+      const cut = mount(<Tabs variant="vertical" />);
+      expect(cut.find('div.rvt-tabs').hasClass('rvt-tabs--vertical')).toBe(true);
+      expect(cut.find('div.rvt-tabs__tablist').prop('aria-orientation')).toEqual('vertical');
+    });
+  });
+
+  describe('Tab toggling', () => {
+
+    let cut = undefined;
+    beforeEach(() => {
+      cut = mount(<Tabs>
+        <Tab title="Tab one" id="t-one">Tab one content</Tab>
+        <Tab title="Tab two" id="t-two">Tab two content</Tab>
+      </Tabs>);
+    })
+
+    it('should render the first tab by default', () => {
+      expect(cut.find('Tab#t-one')).toHaveLength(1);
+    });
+    it('should show the second tab when clicked', () => {
+      expect(cut.find('Tab#t-one')).toHaveLength(1);
+      expect(cut.find('Tab#t-two')).toHaveLength(0);
+      cut.find('button#t-two-tab').simulate('click');
+      expect(cut.find('Tab#t-one')).toHaveLength(0);
+      expect(cut.find('Tab#t-two')).toHaveLength(1);
+    });
+  });
+
+});

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,66 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+
+import * as Rivet from '../util/Rivet';
+
+interface TabsProps {
+  /** The title of the tab */
+  title: string;
+  /**
+   * Optional Rivet style: A fitted or vertical set of tabs.
+   */
+  variant?: 'fitted' | 'vertical'
+}
+
+const initialState = { selected: 0 }
+type TabsState = Readonly<typeof initialState>
+
+class Tabs extends React.PureComponent<TabsProps & React.HTMLAttributes<HTMLDivElement>, TabsState> {
+
+  public readonly state: TabsState = initialState;
+
+  constructor(props) {
+    super(props);
+    this.changeTab = this.changeTab.bind(this);
+  }
+
+  public changeTab(tabNumber) {
+    this.setState({
+      selected: tabNumber
+    });
+  };
+
+  public render() {
+    const { children, className, variant, ...attrs } = this.props;
+    const tabNavigation = React.Children.map(children, (child, index) => {
+      const tab = child as React.ReactElement<any>;
+      const { id, title } = tab.props;
+      return (
+        <button className="rvt-tabs__tab" role="tab" aria-selected={this.state.selected === index} aria-controls={id} id={`${id}-tab`} onClick={() => this.changeTab(index)}>
+          {title}
+        </button>
+      );
+    });
+    const tabContent = React.Children.map(children, (child, index) => {
+      if(index === this.state.selected) {
+        return child;
+      } else {
+        return null;
+      }
+    });
+    const classes = classNames({
+      ['rvt-tabs']: true,
+      [`rvt-tabs--${variant}`]: variant
+    }, className);
+    return (
+      <div {...attrs} className={classes}>
+        <div className="rvt-tabs__tablist" role="tablist" aria-orientation={variant === 'vertical' ? 'vertical' : 'horizontal'}>
+          {tabNavigation}
+        </div>
+        {tabContent}
+      </div>
+    );
+  }
+}
+
+export default Rivet.rivetize(Tabs);

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,6 +27,7 @@ module.exports = {
               'src/components/Badge/*.tsx',
               'src/components/List/*.tsx',
               'src/components/Table/*.tsx',
+              'src/components/Tabs/*.tsx',
             ],
             sections: [
                 {


### PR DESCRIPTION
This adds basic support for tabs as specified on https://rivet.uits.iu.edu/components/page-content/tabs/.  This does not implement the keyboard functionality for accessibility which should be done in #127.