### PR TITLE
Add support for addons and the switch component

### DIFF
--- a/addons/index.js
+++ b/addons/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../build/dist/components/Addons');

--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "react-docgen-typescript": "1.7.0",
     "react-scripts-ts": "2.17.0",
     "react-styleguidist": "7.2.5",
+    "rivet-switch": "0.1.1-alpha",
     "rivet-uits": "1.0.0",
     "semantic-release": "15.9.12",
     "typescript": "2.9.2"
   },
   "files": [
-    "build/dist/components"
+    "build/dist/components",
+    "addons"
   ],
   "jest": {
     "collectCoverageFrom": [

--- a/src/components/Addons/Switch/Switch.md
+++ b/src/components/Addons/Switch/Switch.md
@@ -1,0 +1,64 @@
+<div class="rvt-alert rvt-alert--error rvt-m-bottom-lg" role="alert" aria-labelledby="error-alert-title">
+    <span class="rvt-alert__title" id="error-alert-title">Add-on Component</span>
+    <p class="rvt-alert__message">Add-on components require additional modules to be installed before they can be used and are imported in a different fashion.</p>
+</div>
+
+### Installation and usage
+
+This component is a Rivet add-on so it requires an additional NPM module to be installed before it can be used.  The following command can be used to install the extra dependency:
+
+```sh
+npm install rivet-switch
+```
+
+ Or with yarn,
+
+```sh
+yarn add rivet-switch
+```
+
+After the dependency has been added you may import the component through the "addons" submodule:
+
+```typescript
+import { Switch } from 'rivet-react/addons';
+```
+
+### Default switches
+
+```jsx
+<div className="rvt-display-flex rvt-vertical-center rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm"><strong>Email</strong> notification</span>
+  <Switch defaultValue="off" />
+</div>
+
+
+<div className="rvt-display-flex rvt-vertical-center rvt-border-top rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm"><strong>Two-factor</strong> authenticaton <a href="#">What is this?</a></span>
+  <Switch variant="success" />
+</div>
+
+<div className="rvt-display-flex rvt-vertical-center rvt-border-top rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm">Use my location</span>
+  <Switch variant="danger" />
+</div>
+```
+
+### Small switches
+
+```jsx
+<div className="rvt-display-flex rvt-vertical-center rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm"><strong>Small email</strong> notification</span>
+  <Switch size="small" />
+</div>
+
+
+<div className="rvt-display-flex rvt-vertical-center rvt-border-top rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm"><strong>Two-factor</strong> authenticaton <a href="#">What is this?</a></span>
+  <Switch variant="success" size="small" />
+</div>
+
+<div className="rvt-display-flex rvt-vertical-center rvt-border-top rvt-p-top-md rvt-p-bottom-md">
+  <span className="rvt-m-right-sm">Use my location</span>
+  <Switch variant="danger" size="small" />
+</div>
+```

--- a/src/components/Addons/Switch/Switch.test.tsx
+++ b/src/components/Addons/Switch/Switch.test.tsx
@@ -1,0 +1,43 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+import Switch from './Switch';
+
+describe('<Switch />', () => {
+
+    describe('Rendering and text', () => {
+        it('should render without throwing an error', () => {
+            const cut = mount(<Switch />);
+            expect(cut.find('button.rvt-switch')).toHaveLength(1);
+        });
+        it('should take an id', () => {
+            const cut = mount(<Switch id="the_id"/>);
+            expect(cut.find('button.rvt-switch#the_id')).toHaveLength(1);
+        });
+        it('should toggle the aria-checked attribute', () => {
+          const cut = mount(<Switch />);
+          expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(true);
+          cut.find('button.rvt-switch').simulate('click');
+          expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(false);
+        });
+        it('should allow you to set the default value', () => {
+          const cut = mount(<Switch defaultValue="off" />);
+          expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(false);
+        });
+    });
+
+    describe('Styling', () => {
+      it('should allow for a small size button', () => {
+        const cut = mount(<Switch size="small" />);
+        expect(cut.find('button.rvt-switch').hasClass('rvt-switch--small')).toBe(true);
+      });
+      it('should have a success variant', () => {
+        const cut = mount(<Switch variant="success" />);
+        expect(cut.find('button.rvt-switch').hasClass('rvt-switch--success')).toBe(true);
+      });
+      it('should have a danger variant', () => {
+        const cut = mount(<Switch variant="danger" />);
+        expect(cut.find('button.rvt-switch').hasClass('rvt-switch--danger')).toBe(true);
+      });
+    });
+
+});

--- a/src/components/Addons/Switch/Switch.test.tsx
+++ b/src/components/Addons/Switch/Switch.test.tsx
@@ -18,6 +18,8 @@ describe('<Switch />', () => {
           expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(true);
           cut.find('button.rvt-switch').simulate('click');
           expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(false);
+          cut.find('button.rvt-switch').simulate('click');
+          expect(cut.find('button.rvt-switch').prop('aria-checked')).toBe(true);
         });
         it('should allow you to set the default value', () => {
           const cut = mount(<Switch defaultValue="off" />);

--- a/src/components/Addons/Switch/Switch.tsx
+++ b/src/components/Addons/Switch/Switch.tsx
@@ -1,0 +1,56 @@
+import * as classNames from 'classnames';
+import * as React from 'react';
+import 'rivet-switch/dist/css/rivet-switch.css';
+
+interface SwitchProps {
+  /**
+   * Sets whether the switch is on or off by default.  Default is "on".
+   */
+  defaultValue?: 'on' | 'off';
+  /**
+   * Optional Rivet style: A small switch
+   */
+  size?: 'small';
+  /**
+   * Optional Rivet style: A success or danger styled switch.
+   */
+  variant?: 'success' | 'danger';
+}
+
+const initialState = { value: 'on' };
+type SwitchState = Readonly<typeof initialState>;
+
+class Switch extends React.PureComponent<SwitchProps & React.HTMLAttributes<HTMLButtonElement>, SwitchState> {
+
+  public readonly state: SwitchState = initialState;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: props.defaultValue || 'on'
+    };
+  }
+
+  public toggle = () => {
+    this.setState({
+      value: this.state.value === 'on' ? 'off' : 'on'
+    });
+  };
+
+  public render() {
+    const { className, size, variant, ...attrs } = this.props;
+    const classes = classNames({
+      'rvt-switch': true,
+      [`rvt-switch--${variant}`]: variant,
+      [`rvt-switch--${size}`]: size,
+    }, className);
+    return (
+      <button {...attrs} className={classes} role="switch" aria-checked={this.state.value === 'on'} value={this.state.value} onClick={this.toggle}>
+        <span className="rvt-switch__on">On</span>
+        <span className="rvt-switch__off">Off</span>
+      </button>
+    );
+  }
+}
+
+export default Switch;

--- a/src/components/Addons/Switch/index.ts
+++ b/src/components/Addons/Switch/index.ts
@@ -1,0 +1,1 @@
+export { default as Switch } from './Switch';

--- a/src/components/Addons/index.ts
+++ b/src/components/Addons/index.ts
@@ -1,0 +1,1 @@
+export * from './Switch';

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -120,6 +120,12 @@ module.exports = {
                 }
             ]
         },
+        {
+            name: 'Addons',
+            components: () => [
+              'src/components/Addons/Switch/*.tsx'
+            ],
+        },
     ],
     webpackConfig: require('react-scripts-ts/config/webpack.config.dev'),
     require: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -8882,7 +8882,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rivet-uits@1.0.0:
+rivet-switch@^0.1.1-alpha:
+  version "0.1.1-alpha"
+  resolved "https://registry.yarnpkg.com/rivet-switch/-/rivet-switch-0.1.1-alpha.tgz#a49ee1e291d223010caeff54351a69703ad61b10"
+  dependencies:
+    rivet-uits "^1.0.0"
+
+rivet-uits@1.0.0, rivet-uits@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rivet-uits/-/rivet-uits-1.0.0.tgz#73f8d011be56cdb3637245d0b9f8af9038a2478a"
 


### PR DESCRIPTION
Adds support for addon components which are kept in a separate submodule.  The instructions for this component include details on how to leverage the component since it requires an additional NPM module and a different sort of import.