### PR TITLE
Update Rivet version 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-react",
-  "version": "0.4.0-alpha",
+  "version": "0.4.1",
   "description": "Rivet React components",
   "author": "",
   "license": "MIT",
@@ -42,7 +42,7 @@
     "react-styleguidist": "7.2.5",
     "rivet-collapsible": "0.1.1-alpha",
     "rivet-switch": "0.1.1-alpha",
-    "rivet-uits": "1.1.0-alpha.2",
+    "rivet-uits": "1.1.0",
     "semantic-release": "15.9.12",
     "typescript": "2.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-react",
-  "version": "0.4.0",
+  "version": "0.4.0-alpha",
   "description": "Rivet React components",
   "author": "",
   "license": "MIT",
@@ -42,7 +42,7 @@
     "react-styleguidist": "7.2.5",
     "rivet-collapsible": "0.1.1-alpha",
     "rivet-switch": "0.1.1-alpha",
-    "rivet-uits": "1.0.0",
+    "rivet-uits": "1.1.0-alpha.2",
     "semantic-release": "15.9.12",
     "typescript": "2.9.2"
   },

--- a/src/components/Alert/Alert.md
+++ b/src/components/Alert/Alert.md
@@ -12,7 +12,7 @@ View the [Rivet documentation for Alerts](https://rivet.uits.iu.edu/components/o
     This system will be unavailable on August 1st due to scheduled system maintenance. Please check back on August 2nd.
 </Alert>
 
-<Alert variant="success" title="Thank you!" margin={{ bottom: 'sm' }}>
+<Alert variant="success" title="Thank you!" margin={{ tb: 'sm' }}>
     We have received your application. Check your email in a few weeks to find out if you’ve been admitted.
 </Alert>
 
@@ -20,7 +20,7 @@ View the [Rivet documentation for Alerts](https://rivet.uits.iu.edu/components/o
     Your changes have not been saved. To save your changes, click 'Save my changes' or click 'Cancel' to exit without saving.
 </Alert>
 
-<Alert variant="error" title="Incorrect User ID or Password">
+<Alert variant="danger" title="Incorrect User ID or Password">
     The user ID and password you entered do not match. Please check your entries and try again. <a href="#">Forgot your user ID or password?</a>
 </Alert>
 ```

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -32,9 +32,9 @@ describe('<Alert />', () => {
             const cut = mount(<Alert variant="info" />);
             expect(cut.find('.rvt-alert').hasClass("rvt-alert--info")).toEqual(true);
         });
-        it('should specify style: message', () => {
-            const cut = mount(<Alert variant="message" />);
-            expect(cut.find('.rvt-alert').hasClass("rvt-alert--message")).toEqual(true);
+        it('should specify style: warning', () => {
+            const cut = mount(<Alert variant="warning" />);
+            expect(cut.find('.rvt-alert').hasClass("rvt-alert--warning")).toEqual(true);
         });
         it('should specify style: success', () => {
             const cut = mount(<Alert variant="success" />);

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -25,8 +25,8 @@ describe('<Alert />', () => {
 
     describe('Styling', () => {
         it('should specify style: error', () => {
-            const cut = mount(<Alert variant="error" />);
-            expect(cut.find('.rvt-alert').hasClass("rvt-alert--error")).toEqual(true);
+            const cut = mount(<Alert variant="danger" />);
+            expect(cut.find('.rvt-alert').hasClass("rvt-alert--danger")).toEqual(true);
         });
         it('should specify style: info', () => {
             const cut = mount(<Alert variant="info" />);

--- a/src/components/Alert/DismissibleAlert.md
+++ b/src/components/Alert/DismissibleAlert.md
@@ -1,7 +1,7 @@
 The `DismissibleAlert` allows the user to remove the alert from view. This component provides a close button and implements visibility state management for a standard `Alert`.
 
 ```jsx
-<DismissibleAlert variant="error" title="Error" onDismiss={() => window.alert('Dismissed!')}>
+<DismissibleAlert variant="danger" title="Error" onDismiss={() => window.alert('Dismissed!')}>
   A friendly error for you that can be dismissed!
 </DismissibleAlert>
 ```

--- a/src/components/Alert/DismissibleAlert.test.tsx
+++ b/src/components/Alert/DismissibleAlert.test.tsx
@@ -22,8 +22,8 @@ describe('<Alert />', () => {
 
     describe('Styling', () => {
         it('should specify style: error', () => {
-            const cut = mount(<DismissibleAlert variant="error" />);
-            expect(cut.find('.rvt-alert').hasClass("rvt-alert--error")).toEqual(true);
+            const cut = mount(<DismissibleAlert variant="danger" />);
+            expect(cut.find('.rvt-alert').hasClass("rvt-alert--danger")).toEqual(true);
         });
         it('should specify style: info', () => {
             const cut = mount(<DismissibleAlert variant="info" />);

--- a/src/components/Alert/DismissibleAlert.test.tsx
+++ b/src/components/Alert/DismissibleAlert.test.tsx
@@ -29,7 +29,7 @@ describe('<Alert />', () => {
             const cut = mount(<DismissibleAlert variant="info" />);
             expect(cut.find('.rvt-alert').hasClass("rvt-alert--info")).toEqual(true);
         });
-        it('should specify style: message', () => {
+        it('should specify style: warning', () => {
             const cut = mount(<DismissibleAlert variant="warning" />);
             expect(cut.find('.rvt-alert').hasClass("rvt-alert--warning")).toEqual(true);
         });

--- a/src/components/Alert/DismissibleAlert.test.tsx
+++ b/src/components/Alert/DismissibleAlert.test.tsx
@@ -30,8 +30,8 @@ describe('<Alert />', () => {
             expect(cut.find('.rvt-alert').hasClass("rvt-alert--info")).toEqual(true);
         });
         it('should specify style: message', () => {
-            const cut = mount(<DismissibleAlert variant="message" />);
-            expect(cut.find('.rvt-alert').hasClass("rvt-alert--message")).toEqual(true);
+            const cut = mount(<DismissibleAlert variant="warning" />);
+            expect(cut.find('.rvt-alert').hasClass("rvt-alert--warning")).toEqual(true);
         });
         it('should specify style: success', () => {
             const cut = mount(<DismissibleAlert variant="success" />);

--- a/src/components/Alert/InlineAlert.test.tsx
+++ b/src/components/Alert/InlineAlert.test.tsx
@@ -5,19 +5,19 @@ import InlineAlert from './InlineAlert';
 describe('Inline Alerts', () => {
     it('should have "info" styling with the info variant', () => { 
         const cut = mount(<InlineAlert variant="info">🤔</InlineAlert>);
-        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-info")).toBe(true);
+        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
     });
     it('should have "valid" styling with the valid variant', () => { 
         const cut = mount(<InlineAlert variant="valid">😎</InlineAlert>);
-        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-valid")).toBe(true);
+        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
     });
     it('should have "warning" styling with the warning variant', () => { 
         const cut = mount(<InlineAlert variant="warning">🤨</InlineAlert>);
-        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-warning")).toBe(true);
+        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
     });
     it('should have "invalid" styling with the invalid variant', () => { 
         const cut = mount(<InlineAlert variant="invalid">😬</InlineAlert>);
-        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-invalid")).toBe(true);
+        expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
     });
     it('applies class names to the containing div', () => {
         const cut = mount(<InlineAlert variant="invalid" className="foo">😬</InlineAlert>);

--- a/src/components/Alert/common.ts
+++ b/src/components/Alert/common.ts
@@ -5,7 +5,7 @@ export interface StatefulAlertProps {
      * Rivet alert styling. 
      * @see https://rivet.uits.iu.edu/components/overlays/alerts
      */ 
-    variant: "error" | "info" | "message" | "success",
+    variant: "error" | "danger" | "info" | "message" | "success",
     /**
      * Optional alert title
      */
@@ -17,7 +17,7 @@ export interface StatefulAlertProps {
 }
 
 export const statefulPropTypes = {
-    variant: PropTypes.oneOf(['error', 'info', 'message', 'success']).isRequired,
+    variant: PropTypes.oneOf(['error', 'danger', 'info', 'message', 'success']).isRequired,
     title: PropTypes.string,
     onDismiss: PropTypes.func
 };

--- a/src/components/Alert/common.ts
+++ b/src/components/Alert/common.ts
@@ -5,7 +5,7 @@ export interface StatefulAlertProps {
      * Rivet alert styling. 
      * @see https://rivet.uits.iu.edu/components/overlays/alerts
      */ 
-    variant: "error" | "danger" | "info" | "message" | "success",
+    variant: "danger" | "info" | "warning" | "success",
     /**
      * Optional alert title
      */
@@ -17,7 +17,7 @@ export interface StatefulAlertProps {
 }
 
 export const statefulPropTypes = {
-    variant: PropTypes.oneOf(['error', 'danger', 'info', 'message', 'success']).isRequired,
+    variant: PropTypes.oneOf(['danger', 'info', 'warning', 'success']).isRequired,
     title: PropTypes.string,
     onDismiss: PropTypes.func
 };

--- a/src/components/Badge/Badge.md
+++ b/src/components/Badge/Badge.md
@@ -8,7 +8,7 @@ View the [Rivet documentation for Badges](https://rivet.uits.iu.edu/components/p
 <Badge variant="action">Action</Badge>{' '}
 <Badge variant="success">Success</Badge>{' '}
 <Badge variant="warning">Warning</Badge>{' '}
-<Badge variant="error">Error</Badge>
+<Badge variant="danger">Error</Badge>
 ```
 
 ### Secondary Badges
@@ -17,5 +17,5 @@ View the [Rivet documentation for Badges](https://rivet.uits.iu.edu/components/p
 <Badge variant="action" modifier="secondary">Action</Badge>{' '}
 <Badge variant="success" modifier="secondary">Success</Badge>{' '}
 <Badge variant="warning" modifier="secondary">Warning</Badge>{' '}
-<Badge variant="error" modifier="secondary">Error</Badge>
+<Badge variant="danger" modifier="secondary">Error</Badge>
 ```

--- a/src/components/Badge/Badge.md
+++ b/src/components/Badge/Badge.md
@@ -5,17 +5,17 @@ View the [Rivet documentation for Badges](https://rivet.uits.iu.edu/components/p
 ### Default Badges
 ```jsx
 <Badge>Base</Badge>{' '}
-<Badge variant="action">Action</Badge>{' '}
+<Badge variant="info">Info</Badge>{' '}
 <Badge variant="success">Success</Badge>{' '}
 <Badge variant="warning">Warning</Badge>{' '}
-<Badge variant="danger">Error</Badge>
+<Badge variant="danger">Danger</Badge>
 ```
 
 ### Secondary Badges
 ```jsx
 <Badge modifier="secondary">Base</Badge>{' '}
-<Badge variant="action" modifier="secondary">Action</Badge>{' '}
+<Badge variant="info" modifier="secondary">Info</Badge>{' '}
 <Badge variant="success" modifier="secondary">Success</Badge>{' '}
 <Badge variant="warning" modifier="secondary">Warning</Badge>{' '}
-<Badge variant="danger" modifier="secondary">Error</Badge>
+<Badge variant="danger" modifier="secondary">Danger</Badge>
 ```

--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -17,18 +17,18 @@ describe('<Badge />', () => {
             expect(cut.find('span').hasClass('foo')).toBe(true);
         });
         it('should apply variant class', () => {
-            const cut = mount(<Badge variant="action" />);
-            expect(cut.find('span').hasClass('rvt-badge--action')).toBe(true);
+            const cut = mount(<Badge variant="info" />);
+            expect(cut.find('span').hasClass('rvt-badge--info')).toBe(true);
         });
         it('should apply secondary role', () => {
             const cut = mount(<Badge modifier="secondary" />);
             expect(cut.find('span').hasClass('rvt-badge--secondary')).toBe(true);
         });
         it('should apply secondary variant class appropriately', () => {
-            const cut = mount(<Badge variant="action" modifier="secondary" />);
-            expect(cut.find('span').hasClass('rvt-badge--action')).toBe(false);
+            const cut = mount(<Badge variant="info" modifier="secondary" />);
+            expect(cut.find('span').hasClass('rvt-badge--info')).toBe(false);
             expect(cut.find('span').hasClass('rvt-badge--secondary')).toBe(false);
-            expect(cut.find('span').hasClass('rvt-badge--action-secondary')).toBe(true);
+            expect(cut.find('span').hasClass('rvt-badge--info-secondary')).toBe(true);
         });
     });
 });

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -9,14 +9,14 @@ interface BadgeProps {
      */
     modifier?: 'secondary',
     /**
-     * Optional Rivet style: an action/error/success/warning badge.
+     * Optional Rivet style: an info/danger/success/warning badge.
      */
-    variant?: 'action' | 'error' | 'danger' | 'success' | 'warning';
+    variant?: 'info' | 'danger' | 'success' | 'warning';
 }
 
 const propTypes = {
     role: PropTypes.oneOf(['secondary']),
-    variant: PropTypes.oneOf(['action', 'error', 'success', 'warning'])
+    variant: PropTypes.oneOf(['info', 'danger', 'success', 'warning'])
 };
 
 const Badge : React.SFC<BadgeProps & React.HTMLAttributes<HTMLDivElement>> = ({ children, className, modifier, variant, ...attrs }) => {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -11,7 +11,7 @@ interface BadgeProps {
     /**
      * Optional Rivet style: an action/error/success/warning badge.
      */
-    variant?: 'action' | 'error' | 'success' | 'warning';
+    variant?: 'action' | 'error' | 'danger' | 'success' | 'warning';
 }
 
 const propTypes = {

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -48,27 +48,27 @@ describe('<Input />', () => {
     describe("Inline Alerts", () => {
         it('info style', () => { 
             const cut = mount(<Input variant="info" label="Label" note="🤔"/>);
-            expect(cut.find('input').hasClass("rvt-has-info")).toEqual(true);
+            expect(cut.find('input').hasClass("rvt-validation-info")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-info")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
             const cut = mount(<Input variant="valid" label="Label" note="😎" />);
-            expect(cut.find('input').hasClass("rvt-is-valid")).toEqual(true);
+            expect(cut.find('input').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-valid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
         });
         it('warning style', () => { 
             const cut = mount(<Input variant="warning" label="Label" note="🤨"/>);
-            expect(cut.find('input').hasClass("rvt-has-warning")).toEqual(true);
+            expect(cut.find('input').hasClass("rvt-validation-warning")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-warning")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
             const cut = mount(<Input variant="invalid" label="Label" note="😬"/>);
-            expect(cut.find('input').hasClass("rvt-is-invalid")).toEqual(true);
+            expect(cut.find('input').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(true);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-invalid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
         });
     });
 });

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import * as Rivet from '../util/Rivet';
 import Input from './Input';
 
 describe('<Input />', () => {

--- a/src/components/Input/Select.test.tsx
+++ b/src/components/Input/Select.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import * as Rivet from '../util/Rivet';
 import Select from './Select';
 
 describe('<Select />', () => {

--- a/src/components/Input/Select.test.tsx
+++ b/src/components/Input/Select.test.tsx
@@ -55,27 +55,27 @@ describe('<Select />', () => {
     describe("Inline Alerts", () => {
         it('info style', () => { 
             const cut = mount(<Select variant="info" label="Label" note="🤔"/>);
-            expect(cut.find('select').hasClass("rvt-has-info")).toEqual(true);
+            expect(cut.find('select').hasClass("rvt-validation-info")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-info")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
             const cut = mount(<Select variant="valid" label="Label" note="😎" />);
-            expect(cut.find('select').hasClass("rvt-is-valid")).toEqual(true);
+            expect(cut.find('select').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-valid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
         });
         it('warning style', () => { 
             const cut = mount(<Select variant="warning" label="Label" note="🤨"/>);
-            expect(cut.find('select').hasClass("rvt-has-warning")).toEqual(true);
+            expect(cut.find('select').hasClass("rvt-validation-warning")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-warning")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
             const cut = mount(<Select variant="invalid" label="Label" note="😬"/>);
-            expect(cut.find('select').hasClass("rvt-is-invalid")).toEqual(true);
+            expect(cut.find('select').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(true);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-invalid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
         });
     });
 });

--- a/src/components/Input/Textarea.test.tsx
+++ b/src/components/Input/Textarea.test.tsx
@@ -43,27 +43,27 @@ describe('<Texarea />', () => {
     describe("Inline Alerts", () => {
         it('info style', () => { 
             const cut = mount(<Textarea variant="info" label="Label" note="🤔"/>);
-            expect(cut.find('textarea').hasClass("rvt-has-info")).toEqual(true);
+            expect(cut.find('textarea').hasClass("rvt-validation-info")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-info")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
             const cut = mount(<Textarea variant="valid" label="Label" note="😎"/>);
-            expect(cut.find('textarea').hasClass("rvt-is-valid")).toEqual(true);
+            expect(cut.find('textarea').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-valid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
         });
         it('warning style', () => { 
             const cut = mount(<Textarea variant="warning" label="Label" note="🤨"/>);
-            expect(cut.find('textarea').hasClass("rvt-has-warning")).toEqual(true);
+            expect(cut.find('textarea').hasClass("rvt-validation-warning")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(false);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--has-warning")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
             const cut = mount(<Textarea variant="invalid" label="Label" note="😬"/>);
-            expect(cut.find('textarea').hasClass("rvt-is-invalid")).toEqual(true);
+            expect(cut.find('textarea').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(true);
-            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--is-invalid")).toBe(true);
+            expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
         });
     });
 });

--- a/src/components/Input/common.tsx
+++ b/src/components/Input/common.tsx
@@ -19,7 +19,7 @@ export interface TextProps {
 
 const inputClassName = (variant) => 
     variant
-    ? `rvt-${validationClass(variant)}`
+    ? `rvt-validation-${validationClass(variant)}`
     : '';
 
 const noteFragment = (id : string, variant, note? : React.ReactNode) => 

--- a/src/components/Panel/Panel.md
+++ b/src/components/Panel/Panel.md
@@ -8,7 +8,7 @@ Panels have a light gray background by default.
 
 ```jsx
 <Panel>
-    <p class="rvt-m-all-remove">Voluptates quas voluptas a est est ut nisi. Laborum debitis perferendis voluptatem. Ut nemo sint itaque qui harum. Id unde qui architecto praesentium quo adipisci vero. Eaque deserunt voluptatum delectus eveniet quas aut modi quo. Exercitationem non voluptatem temporibus.</p>
+    <p className="rvt-m-all-remove">Voluptates quas voluptas a est est ut nisi. Laborum debitis perferendis voluptatem. Ut nemo sint itaque qui harum. Id unde qui architecto praesentium quo adipisci vero. Eaque deserunt voluptatum delectus eveniet quas aut modi quo. Exercitationem non voluptatem temporibus.</p>
 </Panel>
 ```
 
@@ -18,6 +18,6 @@ Use the *light* `variant` to create a panel with a white background.
 
 ```jsx
 <Panel variant="light">
-    <p class="rvt-m-all-remove">Voluptates quas voluptas a est est ut nisi. Laborum debitis perferendis voluptatem. Ut nemo sint itaque qui harum. Id unde qui architecto praesentium quo adipisci vero. Eaque deserunt voluptatum delectus eveniet quas aut modi quo. Exercitationem non voluptatem temporibus.</p>
+    <p className="rvt-m-all-remove">Voluptates quas voluptas a est est ut nisi. Laborum debitis perferendis voluptatem. Ut nemo sint itaque qui harum. Id unde qui architecto praesentium quo adipisci vero. Eaque deserunt voluptatum delectus eveniet quas aut modi quo. Exercitationem non voluptatem temporibus.</p>
 </Panel>
 ```

--- a/src/components/Panel/Panel.test.tsx
+++ b/src/components/Panel/Panel.test.tsx
@@ -28,7 +28,7 @@ describe('<Panel />', () => {
         it('should apply custom classes', () => {
             const className = 'foo';
             const cut = mount(<Panel className={className} />);
-            expect(cut.find('div').prop('className').split(' ')).toContain(className);
+            expect(cut.find('div').hasClass(className)).toBe(true);
         });
 
         it('should render children', () => {

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import * as Rivet from '../util/Rivet';
 import RadioButton from './RadioButton';
 
 describe('<RadioButton />', () => {

--- a/src/components/Table/Table.md
+++ b/src/components/Table/Table.md
@@ -118,3 +118,81 @@ The *plain* `variant` will remove all borders and formatting from the table.
     </tbody>
 </Table>
 ```
+
+### Compact Table
+
+The *compact* `variant` decreases the amount of padding applied to each table cell.
+
+```jsx
+<Table variant="compact">
+    <caption className="rvt-sr-only">Table example one</caption>
+    <thead>
+        <tr>
+            <th scope="col">Service</th>
+            <th scope="col">Description</th>
+            <th scope="col">URL</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th scope="row">One.IU</th>
+            <td>One.IU was created to bring a modern app store experience to finding what you need at IU. With One.IU, you search for what you want to do, and click to launch it.</td>
+            <td><a href="#">one.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Box</th>
+            <td>Box is a no-cost cloud storage and collaboration environment available to students, faculty, and staff.</td>
+            <td><a href="#">box.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Zoom</th>
+            <td>Zoom is a web collaboration tool available to all Indiana University students, faculty, and staff.</td>
+            <td><a href="#">zoom.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Canvas</th>
+            <td>Canvas is a learning management system developed by Instructure, Inc.</td>
+            <td><a href="#">canvas.iu.edu</a></td>
+        </tr>
+    </tbody>
+</Table>
+```
+
+### Cells Table
+
+The *cells* `variant` adds borders to all table cells.
+
+```jsx
+<Table variant="cells">
+    <caption className="rvt-sr-only">Table example one</caption>
+    <thead>
+        <tr>
+            <th scope="col">Service</th>
+            <th scope="col">Description</th>
+            <th scope="col">URL</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <th scope="row">One.IU</th>
+            <td>One.IU was created to bring a modern app store experience to finding what you need at IU. With One.IU, you search for what you want to do, and click to launch it.</td>
+            <td><a href="#">one.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Box</th>
+            <td>Box is a no-cost cloud storage and collaboration environment available to students, faculty, and staff.</td>
+            <td><a href="#">box.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Zoom</th>
+            <td>Zoom is a web collaboration tool available to all Indiana University students, faculty, and staff.</td>
+            <td><a href="#">zoom.iu.edu</a></td>
+        </tr>
+        <tr>
+            <th scope="row">Canvas</th>
+            <td>Canvas is a learning management system developed by Instructure, Inc.</td>
+            <td><a href="#">canvas.iu.edu</a></td>
+        </tr>
+    </tbody>
+</Table>
+```

--- a/src/components/Table/Table.md
+++ b/src/components/Table/Table.md
@@ -4,7 +4,7 @@ View the [Rivet Documentation for Tables](https://rivet.uits.iu.edu/components/p
 
 ### Default Table
 
-Default tables in Rivet come with styled headers and bottom borders on row to help with readability.
+Default tables in Rivet come with styled headers and bottom borders on row to help with readability. This can be used along with the `compact` and `cells` booleans.
 
 ```jsx
 <Table>
@@ -43,7 +43,7 @@ Default tables in Rivet come with styled headers and bottom borders on row to he
 
 ### Striped Table
 
-The *stripes* `variant` to alternate light gray backgrounds on table rows for improved scannability.
+The *stripes* `variant` to alternate light gray backgrounds on table rows for improved scannability. This can be used along with the `compact` and `cells` booleans.
 
 ```jsx
 <Table variant="stripes">
@@ -82,7 +82,7 @@ The *stripes* `variant` to alternate light gray backgrounds on table rows for im
 
 ### Plain Table
 
-The *plain* `variant` will remove all borders and formatting from the table.
+The *plain* `variant` will remove all borders and formatting from the table. This can be used along with the `compact` boolean.
 
 ```jsx
 <Table variant="plain">
@@ -121,10 +121,10 @@ The *plain* `variant` will remove all borders and formatting from the table.
 
 ### Compact Table
 
-The *compact* `variant` decreases the amount of padding applied to each table cell.
+The *compact* `boolean` decreases the amount of padding applied to each table cell.
 
 ```jsx
-<Table variant="compact">
+<Table compact>
     <caption className="rvt-sr-only">Table example one</caption>
     <thead>
         <tr>
@@ -160,10 +160,10 @@ The *compact* `variant` decreases the amount of padding applied to each table ce
 
 ### Cells Table
 
-The *cells* `variant` adds borders to all table cells.
+The *cells* `boolean` adds borders to all table cells.
 
 ```jsx
-<Table variant="cells">
+<Table cells>
     <caption className="rvt-sr-only">Table example one</caption>
     <thead>
         <tr>

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -18,9 +18,9 @@ describe('<Table />', () => {
         });
         it('should apply variant classes', () => {
             expect(mount(<Table variant="stripes" />).find('table.rvt-table-stripes')).toHaveLength(1);
-          expect(mount(<Table variant="plain" />).find('table.rvt-table-plain')).toHaveLength(1);
-          expect(mount(<Table variant="compact" />).find('table.rvt-table-compact')).toHaveLength(1);
-          expect(mount(<Table variant="cells" />).find('table.rvt-table-cells')).toHaveLength(1);
+            expect(mount(<Table variant="plain" />).find('table.rvt-table-plain')).toHaveLength(1);
+            expect(mount(<Table variant="compact" />).find('table.rvt-table-compact')).toHaveLength(1);
+            expect(mount(<Table variant="cells" />).find('table.rvt-table-cells')).toHaveLength(1);
         });
     });
 });

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -18,7 +18,9 @@ describe('<Table />', () => {
         });
         it('should apply variant classes', () => {
             expect(mount(<Table variant="stripes" />).find('table.rvt-table-stripes')).toHaveLength(1);
-            expect(mount(<Table variant="plain" />).find('table.rvt-table-plain')).toHaveLength(1);
+          expect(mount(<Table variant="plain" />).find('table.rvt-table-plain')).toHaveLength(1);
+          expect(mount(<Table variant="compact" />).find('table.rvt-table-compact')).toHaveLength(1);
+          expect(mount(<Table variant="cells" />).find('table.rvt-table-cells')).toHaveLength(1);
         });
     });
 });

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -19,8 +19,15 @@ describe('<Table />', () => {
         it('should apply variant classes', () => {
             expect(mount(<Table variant="stripes" />).find('table.rvt-table-stripes')).toHaveLength(1);
             expect(mount(<Table variant="plain" />).find('table.rvt-table-plain')).toHaveLength(1);
-            expect(mount(<Table variant="compact" />).find('table.rvt-table-compact')).toHaveLength(1);
-            expect(mount(<Table variant="cells" />).find('table.rvt-table-cells')).toHaveLength(1);
+            expect(mount(<Table compact />).find('table.rvt-table-compact')).toHaveLength(1);
+            expect(mount(<Table cells />).find('table.rvt-table-cells')).toHaveLength(1);
+            expect(mount(<Table variant="plain" compact />).find('table.rvt-table-compact')).toHaveLength(1);
+            expect(mount(<Table variant="plain" compact />).find('table.rvt-table-plain')).toHaveLength(1);
+            expect(mount(<Table variant="plain" cells />).find('table.rvt-table-cells')).toHaveLength(0);
+            expect(mount(<Table variant="plain" cells />).find('table.rvt-table-plain')).toHaveLength(1);
+            expect(mount(<Table variant="stripes" cells compact />).find('table.rvt-table-stripes')).toHaveLength(1);
+            expect(mount(<Table variant="stripes" cells compact />).find('table.rvt-table-cells')).toHaveLength(1);
+            expect(mount(<Table variant="stripes" cells compact />).find('table.rvt-table-compact')).toHaveLength(1);
         });
     });
 });

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -6,16 +6,25 @@ interface TableProps {
     /**
      * Optional Rivet style which changes the look and feel of the rendered table.
      */
-    variant?: 'stripes' | 'plain' | 'compact' | 'cells'
+    variant?: 'stripes' | 'plain'
+
+    /**
+     * Determines if the table is compact.  Default is not compact.
+     */
+    compact?: boolean;
+
+    /**
+     * Determines if the table has borders around all cells.  Default is no borders around cells.
+     */
+    cells?: boolean;
 }
 
 const Table : React.SFC<TableProps & React.HTMLAttributes<HTMLTableElement>> =
-({ children, className, variant, ...attrs }) => {
+({ children, className, variant, compact, cells, ...attrs }) => {
     const classes = classNames({
-        ['rvt-table-plain']: variant === 'plain',
-        ['rvt-table-stripes']: variant === 'stripes',
-        ['rvt-table-compact']: variant === 'compact',
-        ['rvt-table-cells']: variant === 'cells',
+        [`rvt-table-${variant}`]: variant,
+        ['rvt-table-compact']: compact,
+        ['rvt-table-cells']: cells && variant !== 'plain',
     }, className);
     return (
         <table {...attrs} className={classes}>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -3,17 +3,19 @@ import * as React from 'react';
 import * as Rivet from '../util/Rivet';
 
 interface TableProps {
-    /** 
+    /**
      * Optional Rivet style which changes the look and feel of the rendered table.
      */
-    variant?: 'stripes' | 'plain'
+    variant?: 'stripes' | 'plain' | 'compact' | 'cells'
 }
 
-const Table : React.SFC<TableProps & React.HTMLAttributes<HTMLTableElement>> = 
+const Table : React.SFC<TableProps & React.HTMLAttributes<HTMLTableElement>> =
 ({ children, className, variant, ...attrs }) => {
     const classes = classNames({
         ['rvt-table-plain']: variant === 'plain',
         ['rvt-table-stripes']: variant === 'stripes',
+        ['rvt-table-compact']: variant === 'compact',
+        ['rvt-table-cells']: variant === 'cells',
     }, className);
     return (
         <table {...attrs} className={classes}>

--- a/src/components/Tabs/Tabs.md
+++ b/src/components/Tabs/Tabs.md
@@ -7,20 +7,20 @@ View the [Rivet documentation for Tabs](https://rivet.uits.iu.edu/components/pag
 ```jsx
 <Tabs>
   <Tab id="t-one" title="Tab one">
-    <span class="rvt-ts-23 rvt-text-bold">Panel 1</span>
+    <span className="rvt-ts-23 rvt-text-bold">Panel 1</span>
     <p>
         Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
         in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </Tab>
   <Tab id="t-two" title="Tab two">
-    <span class="rvt-ts-23 rvt-text-bold">Panel 2</span>
+    <span className="rvt-ts-23 rvt-text-bold">Panel 2</span>
     <p>
         Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </Tab>
   <Tab id="t-three" title="Tab three">
-    <span class="rvt-ts-23 rvt-text-bold">A grid inside a tab panel</span>
+    <span className="rvt-ts-23 rvt-text-bold">A grid inside a tab panel</span>
     <Row>
       <Col md={4}>
         <p>
@@ -44,20 +44,20 @@ Applying the `fitted` variant will make the tabs take up equal amounts of the sp
 ```jsx
 <Tabs variant="fitted">
   <Tab id="t-one" title="Tab one">
-    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Sue’s Salads</span>
+    <span className="rvt-ts-26 rvt-text-bold rvt-display-block">Sue’s Salads</span>
     <p>
         Panel 1: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute
         irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </Tab>
   <Tab id="t-two" title="Tab two">
-    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
+    <span className="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
     <p>
         Panel 2: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
   </Tab>
   <Tab id="t-three" title="Tab three">
-    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Food n’ Stuff</span>
+    <span className="rvt-ts-26 rvt-text-bold rvt-display-block">Food n’ Stuff</span>
     <p>
         Panel 3: Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>
@@ -72,7 +72,7 @@ The `vertical` variant creates a set of tabs where the tab controls display in a
 ```jsx
 <Tabs variant="vertical">
   <Tab id="t-one" title="Tab one">
-    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">Paunch Burger</span>
+    <span className="rvt-ts-26 rvt-text-bold rvt-display-block">Paunch Burger</span>
     <p>
         Panel 1: Lorem ipsum dolor sit amet,
         <a href="#0">consectetur adipisicing elit</a>, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor
@@ -80,7 +80,7 @@ The `vertical` variant creates a set of tabs where the tab controls display in a
     </p>
   </Tab>
   <Tab id="t-two" title="Tab two">
-    <span class="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
+    <span className="rvt-ts-26 rvt-text-bold rvt-display-block">JJ’s Diner</span>
     <p>
         Panel 2: Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
     </p>

--- a/src/components/util/Rivet.test.tsx
+++ b/src/components/util/Rivet.test.tsx
@@ -19,19 +19,23 @@ const DemoComponent = Rivet.rivetize(({ children, ...attrs }) => (
     });
   
     it('discriminates bounds', () => {
-        const cut = mount(<DemoComponent margin={{ top: "xs", right:"sm", bottom: "md", left: "lg" }} />);
+        const cut = mount(<DemoComponent margin={{ top: "xs", right:"sm", bottom: "md", left: "lg", lr: "xl", tb: "xxl" }} />);
         expect(cut.find('div').hasClass('rvt-m-top-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-right-sm')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-bottom-md')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-left-lg')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-m-lr-xl')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-m-tb-xxl')).toBe(true);
     });
   
     it('discriminates sizings', () => {
-        const cut = mount(<DemoComponent margin={{ xs: ['top', "bottom"], md: "left", lg: "right" }} />);
+        const cut = mount(<DemoComponent margin={{ xs: ['top', "bottom"], md: "left", lg: "right", xl: "lr", xxl: "tb" }} />);
         expect(cut.find('div').hasClass('rvt-m-top-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-bottom-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-left-md')).toBe(true);
         expect(cut.find('div').hasClass('rvt-m-right-lg')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-m-lr-xl')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-m-tb-xxl')).toBe(true);
     }); 
   }); 
 
@@ -47,19 +51,23 @@ const DemoComponent = Rivet.rivetize(({ children, ...attrs }) => (
     });
   
     it('discriminates bounds', () => {
-        const cut = mount(<DemoComponent padding={{ top: "xs", right:"sm", bottom: "md", left: "lg" }} />);
+        const cut = mount(<DemoComponent padding={{ top: "xs", right:"sm", bottom: "md", left: "lg", lr: "xl", tb: "xxl" }} />);
         expect(cut.find('div').hasClass('rvt-p-top-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-right-sm')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-bottom-md')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-left-lg')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-p-lr-xl')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-p-tb-xxl')).toBe(true);
     });
   
     it('discriminates sizings', () => {
-        const cut = mount(<DemoComponent padding={{ xs: ['top', "bottom"], md: "left", lg: "right" }} />);
+        const cut = mount(<DemoComponent padding={{ xs: ['top', "bottom"], md: "left", lg: "right", xl: "lr", xxl: "tb" }} />);
         expect(cut.find('div').hasClass('rvt-p-top-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-bottom-xs')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-left-md')).toBe(true);
         expect(cut.find('div').hasClass('rvt-p-right-lg')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-p-lr-xl')).toBe(true);
+        expect(cut.find('div').hasClass('rvt-p-tb-xxl')).toBe(true);
     }); 
   }); 
 

--- a/src/components/util/Rivet.test.tsx
+++ b/src/components/util/Rivet.test.tsx
@@ -81,6 +81,13 @@ const DemoComponent = Rivet.rivetize(({ children, ...attrs }) => (
         expect(mount(<DemoComponent typescale={12} />).find('div').hasClass('rvt-ts-12')).toBe(true);
         expect(mount(<DemoComponent typescale={23} />).find('div').hasClass('rvt-ts-23')).toBe(true);
         expect(mount(<DemoComponent typescale="base" />).find('div').hasClass('rvt-ts-base')).toBe(true);
+        expect(mount(<DemoComponent typescale="xxs" />).find('div').hasClass('rvt-ts-xxs')).toBe(true);
+        expect(mount(<DemoComponent typescale="xs" />).find('div').hasClass('rvt-ts-xs')).toBe(true);
+        expect(mount(<DemoComponent typescale="sm" />).find('div').hasClass('rvt-ts-sm')).toBe(true);
+        expect(mount(<DemoComponent typescale="md" />).find('div').hasClass('rvt-ts-md')).toBe(true);
+        expect(mount(<DemoComponent typescale="lg" />).find('div').hasClass('rvt-ts-lg')).toBe(true);
+        expect(mount(<DemoComponent typescale="xl" />).find('div').hasClass('rvt-ts-xl')).toBe(true);
+        expect(mount(<DemoComponent typescale="xxl" />).find('div').hasClass('rvt-ts-xxl')).toBe(true);
       });
   });
   

--- a/src/components/util/Rivet.tsx
+++ b/src/components/util/Rivet.tsx
@@ -38,11 +38,11 @@ export interface Props {
     display?: Display,
 }
 
-export type Typescale = "base" | 12 | 14 | 16 | 18 | 20 | 23 | 26 | 29 | 32 | 36 | 41 | 46 | 52;
+export type Typescale = "base" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | 12 | 14 | 16 | 18 | 20 | 23 | 26 | 29 | 32 | 36 | 41 | 46 | 52;
 export type Size = 'xxs' | 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 export const Sizes = [ 'xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl' ];
-export type Edge = 'top' | 'right' | 'bottom' | 'left';
-export const Edges = [ 'top', 'right', 'bottom', 'left' ];
+export type Edge = 'top' | 'right' | 'bottom' | 'left' | 'tb' | 'lr';
+export const Edges = [ 'top', 'right', 'bottom', 'left', 'tb', 'lr' ];
 export type Display = "inline" | "inline-block" | "block" | "flex" | "flex-vertical-center";
 export type Border = "all" | "radius" | Edge | Edge[]
 export type Hidden = "sm-down" | "md-down" | "lg-down" | "xl-down" | "xxl-down" | "sm-up" | "md-up" | "lg-up" | "xl-up" | "xxl-up"
@@ -55,7 +55,9 @@ export interface BoxStyle {
     right?: Size,
     bottom?: Size,
     left?: Size,
-    // 
+    lr?: Size,
+    tb?: Size,
+    //
     xxs?: Edge | Edge[],
     xs?:  Edge | Edge[],
     sm?: Edge | Edge[],

--- a/src/components/util/validation.tsx
+++ b/src/components/util/validation.tsx
@@ -5,19 +5,19 @@ type ValidationType = 'info' | 'invalid' | 'valid' | 'warning';
 
 const validationDisplayOptions : object = {
     info: {
-        className: 'has-info',
+        className: 'info',
         icon: <Icon name="info" />
     },
     valid: {
-        className: 'is-valid',
+        className: 'success',
         icon: <Icon name="success" />
     },
     warning: {
-        className: 'has-warning',
+        className: 'warning',
         icon: <Icon name="warning" />
     },
     invalid: {
-        className: 'is-invalid',
+        className: 'danger',
         icon: <Icon name="error" />
     },
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8894,9 +8894,9 @@ rivet-switch@0.1.1-alpha:
   dependencies:
     rivet-uits "^1.0.0"
 
-rivet-uits@1.1.0-alpha.2:
-  version "1.1.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/rivet-uits/-/rivet-uits-1.1.0-alpha.2.tgz#ca44618536b7ce674ea1f3ed5340d0f9e40b4038"
+rivet-uits@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rivet-uits/-/rivet-uits-1.1.0.tgz#bd50edae3fd222cd1f8d67416e6513eecf9a4c23"
 
 rivet-uits@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8894,7 +8894,11 @@ rivet-switch@0.1.1-alpha:
   dependencies:
     rivet-uits "^1.0.0"
 
-rivet-uits@1.0.0, rivet-uits@^1.0.0:
+rivet-uits@1.1.0-alpha.2:
+  version "1.1.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/rivet-uits/-/rivet-uits-1.1.0-alpha.2.tgz#ca44618536b7ce674ea1f3ed5340d0f9e40b4038"
+
+rivet-uits@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rivet-uits/-/rivet-uits-1.0.0.tgz#73f8d011be56cdb3637245d0b9f8af9038a2478a"
 


### PR DESCRIPTION
- Adds compact and cell table variants
- Adds lr and tb edges
- Adds new typescale aliases
- Consistent color naming: info, success, warning, danger