### PR TITLE
chore(package): Fix the package version number after last release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivet-react",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Rivet React components",
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
A couple of weeks ago when I released 0.5.0 I'm guessing I did something wrong which prevented semantic-release from updating this appropriately so I'm fixing this now.  This should cause 0.6.0 to be created when we merge the recent changes into master.