### PR TITLE
Add disabled class to pagination item if child is disabled

### DIFF
--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -39,12 +39,19 @@ describe('<Pagination />', () => {
           </Pagination>);
         expect(cut.find('nav > ul.rvt-pagination > li.rvt-pagination__item > a').length).toBe(2);
       });
-      it('should add class when child is disabled', () => {
+      it('should add class when child is disabled with aria attributes', () => {
         const cut = mount(
           <Pagination>
             <a href="#" id="test" aria-disabled="true">Link one</a>
           </Pagination>);
         expect(cut.find('nav > ul.rvt-pagination > li.rvt-pagination__item.is-disabled > a#test').length).toBe(1);
+      });
+      it('should add class when child is disabled', () => {
+        const cut = mount(
+          <Pagination>
+            <button id="test" disabled>Link one</button>
+          </Pagination>);
+        expect(cut.find('nav > ul.rvt-pagination > li.rvt-pagination__item.is-disabled > button#test').length).toBe(1);
       });
       it('should add class when child is the current page', () => {
         const cut = mount(

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -24,7 +24,7 @@ const Pagination : React.SFC<PaginationProps & React.HTMLAttributes<HTMLDivEleme
     const wrappedChildren = React.Children.map(children, (child: React.ReactElement<any>) => {
       const childClasses = classNames({
         'rvt-pagination__item': true,
-        'is-disabled': child.props && child.props['aria-disabled'],
+        'is-disabled': child.props && (child.props['aria-disabled'] || child.props['disabled']),
         'is-active': child.props && child.props['aria-current'] === 'page'
       });
       return (


### PR DESCRIPTION
Modified the Pagination component so it checks for the disabled attribute in addition to the aria-disabled attribute when determining if a pagination item should be disabled