### PR TITLE
Added expected keyboard navigation support to Tabs component

### DIFF
--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -54,4 +54,120 @@ describe('<Tabs />', () => {
     });
   });
 
+  describe('Tab keyboard interactions', () => {
+    let mock;
+
+    beforeEach(() => {
+      mock = mount(
+        <Tabs>
+          <Tab title="Tab one" id="t-one">
+            Tab one content
+          </Tab>
+          <Tab title="Tab two" id="t-two">
+            Tab two content
+          </Tab>
+          <Tab title="Tab three" id="t-three">
+            Tab two content
+          </Tab>
+        </Tabs>
+      );
+    })
+
+    it('Should focus the first tab by default', () => {
+      mock
+      .find('button#t-one-tab')
+      .simulate('click');
+
+      const focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-one-tab')
+        .matchesElement(focusedElement));
+    });
+
+    it('Should focus the next tab when the right arrow key is pressed', () => {
+      mock
+        .find('button#t-one-tab')
+        .simulate('click');
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-one-tab')
+        .matchesElement(focusedElement));
+
+      mock.find('button#t-one-tab').simulate('keydown', {keyCode: 39});
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-two-tab')
+        .matchesElement(focusedElement));
+    });
+
+    it('Should focus the previous tab when the left arrow key is pressed', () => {
+      mock.find('button#t-two-tab').simulate('click');
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-two-tab')
+        .matchesElement(focusedElement));
+
+      mock
+        .find('button#t-one-tab')
+        .simulate('keydown', { keyCode: 37 });
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-one-tab')
+        .matchesElement(focusedElement));
+    });
+
+
+    it('Should focus the last tab when the End key is pressed', () => {
+      mock
+        .find('button#t-one-tab')
+        .simulate('click');
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-one-tab')
+        .matchesElement(focusedElement));
+
+      mock
+        .find('button#t-one-tab')
+        .simulate('keydown', { keyCode: 35 });
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-three-tab')
+        .matchesElement(focusedElement));
+    });
+
+    it('Should focus the first tab when the Home key is pressed', () => {
+      mock
+        .find('button#t-three-tab')
+        .simulate('click');
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-three-tab')
+        .matchesElement(focusedElement));
+
+      mock
+        .find('button#t-three-tab')
+        .simulate('keydown', { keyCode: 36 });
+
+      let focusedElement = document.activeElement;
+
+      expect(mock
+        .find('button#t-three-tab')
+        .matchesElement(focusedElement));
+    });
+  });
 });

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -13,22 +13,94 @@ interface TabsProps {
 }
 
 const initialState = { selected: 0 }
+
 type TabsState = Readonly<typeof initialState>
 
-class Tabs extends React.PureComponent<TabsProps & React.HTMLAttributes<HTMLDivElement>, TabsState> {
-
+class Tabs extends React.PureComponent<
+  TabsProps & React.HTMLAttributes<HTMLDivElement>,
+  TabsState
+> {
   public readonly state: TabsState = initialState;
+
+  /**
+   * Array to hold Tab button refs. This is how we'll manage focus.
+   */
+  public tabRefs: any = [];
+
+  // Key codes for easy reference
+  public readonly keys = {
+    end: 35,
+    home: 36,
+    left: 37,
+    up: 38,
+    right: 39,
+    down: 40
+  };
 
   constructor(props) {
     super(props);
     this.changeTab = this.changeTab.bind(this);
+    this.handleKeydown = this.handleKeydown.bind(this);
   }
 
   public changeTab(tabNumber) {
     this.setState({
       selected: tabNumber
     });
-  };
+  }
+
+  public focusNextTab(tabs, target) {
+    const next = tabs.indexOf(target) + 1;
+
+    !tabs[next] ? tabs[0].focus() : tabs[next].focus();
+  }
+
+  public focusPreviousTab(tabs, target) {
+    const prev = tabs.indexOf(target) - 1;
+
+    !tabs[prev] ? tabs[tabs.length - 1].focus() : tabs[prev].focus();
+  }
+
+  public handleKeydown(tabs, target, event) {
+    switch (event.keyCode) {
+      case this.keys.right:
+        this.focusNextTab(tabs, target);
+
+        break;
+      case this.keys.down:
+        event.preventDefault();
+
+        this.focusNextTab(tabs, target);
+
+        break;
+      case this.keys.left:
+        this.focusPreviousTab(tabs, target);
+
+        break;
+      case this.keys.up:
+        event.preventDefault();
+
+        this.focusPreviousTab(tabs, target);
+
+        break;
+      case this.keys.home:
+        event.preventDefault();
+
+        // Focus the first tab button
+        tabs[0].focus();
+
+        break;
+      case this.keys.end:
+        event.preventDefault();
+
+        // Focus the last tab button
+        tabs[tabs.length - 1].focus();
+
+        break;
+      default:
+        break;
+    }
+  }
 
   public render() {
     const { children, className, variant, ...attrs } = this.props;
@@ -36,25 +108,44 @@ class Tabs extends React.PureComponent<TabsProps & React.HTMLAttributes<HTMLDivE
       const tab = child as React.ReactElement<any>;
       const { id, title } = tab.props;
       return (
-        <button className="rvt-tabs__tab" role="tab" aria-selected={this.state.selected === index} aria-controls={id} id={`${id}-tab`} onClick={() => this.changeTab(index)}>
+        <button
+          className="rvt-tabs__tab"
+          role="tab"
+          aria-selected={this.state.selected === index}
+          aria-controls={id}
+          id={`${id}-tab`}
+          onClick={() => this.changeTab(index)}
+          ref={tabControl => this.tabRefs.push(tabControl)}
+          onKeyDown={event =>
+            this.handleKeydown(this.tabRefs, event.target, event)
+          }
+          tabIndex={this.state.selected === index ? undefined : -1}
+        >
           {title}
         </button>
       );
     });
     const tabContent = React.Children.map(children, (child, index) => {
-      if(index === this.state.selected) {
+      if (index === this.state.selected) {
         return child;
       } else {
         return null;
       }
     });
-    const classes = classNames({
-      ['rvt-tabs']: true,
-      [`rvt-tabs--${variant}`]: variant
-    }, className);
+    const classes = classNames(
+      {
+        ['rvt-tabs']: true,
+        [`rvt-tabs--${variant}`]: variant
+      },
+      className
+    );
     return (
       <div {...attrs} className={classes}>
-        <div className="rvt-tabs__tablist" role="tablist" aria-orientation={variant === 'vertical' ? 'vertical' : 'horizontal'}>
+        <div
+          className="rvt-tabs__tablist"
+          role="tablist"
+          aria-orientation={variant === 'vertical' ? 'vertical' : 'horizontal'}
+        >
           {tabNavigation}
         </div>
         {tabContent}

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -125,6 +125,7 @@ class Tabs extends React.PureComponent<
         </button>
       );
     });
+
     const tabContent = React.Children.map(children, (child, index) => {
       if (index === this.state.selected) {
         return child;
@@ -132,6 +133,7 @@ class Tabs extends React.PureComponent<
         return null;
       }
     });
+
     const classes = classNames(
       {
         ['rvt-tabs']: true,
@@ -139,6 +141,7 @@ class Tabs extends React.PureComponent<
       },
       className
     );
+
     return (
       <div {...attrs} className={classes}>
         <div


### PR DESCRIPTION
This PR adds keyboard navigation support to the the Tabs component and should address #127.

Focus management is a _very_ DOM-specific thing, so I'd be interested to talk about how best to handle that in the Rivet React library in a consistent way moving forward. I'm not aware of a way to handle focus expectations in a data-driven/state-specific way, so I've relied heavily on the `ref` React API here.

This is my first foray into Typescript so feedback it definitely welcome :)

I've written tests that pass for me locally, but again, if anyone has ideas about how to improve them (they are a bit repetitive), I'd love some feedback.