### PR TITLE
Fix/clean up variant options in InlineAlert and input components

### DIFF
--- a/src/components/Alert/InlineAlert.md
+++ b/src/components/Alert/InlineAlert.md
@@ -11,7 +11,7 @@ View the [Rivet documentation for Standalone Inline Alerts](https://rivet.uits.i
         <RadioButton name="radio-list-demo" label="Option One" aria-describedby="alert" />
         <RadioButton name="radio-list-demo" label="Option Two" aria-describedby="alert" />
     </List>
-    <InlineAlert id="alert" variant='invalid'>You must choose an option to continue.</InlineAlert>
+    <InlineAlert id="alert" variant="danger">You must choose an option to continue.</InlineAlert>
 </fieldset>
 ```
 
@@ -24,6 +24,6 @@ You can use the `standalone` property to give the alert a subtle background colo
         <RadioButton name="radio-list-demo" label="Option One" aria-describedby="alert" />
         <RadioButton name="radio-list-demo" label="Option Two" aria-describedby="alert" />
     </List>
-    <InlineAlert id="alert" variant='invalid' standalone>You must choose an option to continue.</InlineAlert>
+    <InlineAlert id="alert-standalone" variant="danger" standalone>You must choose an option to continue.</InlineAlert>
 </fieldset>
 ```

--- a/src/components/Alert/InlineAlert.test.tsx
+++ b/src/components/Alert/InlineAlert.test.tsx
@@ -7,7 +7,7 @@ describe('Inline Alerts', () => {
         const cut = mount(<InlineAlert variant="info">🤔</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
     });
-    it('should have "success" styling with the valid variant', () => { 
+    it('should have "success" styling with the success variant', () => { 
         const cut = mount(<InlineAlert variant="success">😎</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
     });
@@ -15,7 +15,7 @@ describe('Inline Alerts', () => {
         const cut = mount(<InlineAlert variant="warning">🤨</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
     });
-    it('should have "danger" styling with the invalid variant', () => { 
+    it('should have "danger" styling with the danger variant', () => { 
         const cut = mount(<InlineAlert variant="danger">😬</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
     });

--- a/src/components/Alert/InlineAlert.test.tsx
+++ b/src/components/Alert/InlineAlert.test.tsx
@@ -7,20 +7,20 @@ describe('Inline Alerts', () => {
         const cut = mount(<InlineAlert variant="info">🤔</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
     });
-    it('should have "valid" styling with the valid variant', () => { 
-        const cut = mount(<InlineAlert variant="valid">😎</InlineAlert>);
+    it('should have "success" styling with the valid variant', () => { 
+        const cut = mount(<InlineAlert variant="success">😎</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
     });
     it('should have "warning" styling with the warning variant', () => { 
         const cut = mount(<InlineAlert variant="warning">🤨</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
     });
-    it('should have "invalid" styling with the invalid variant', () => { 
-        const cut = mount(<InlineAlert variant="invalid">😬</InlineAlert>);
+    it('should have "danger" styling with the invalid variant', () => { 
+        const cut = mount(<InlineAlert variant="danger">😬</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);
     });
     it('applies class names to the containing div', () => {
-        const cut = mount(<InlineAlert variant="invalid" className="foo">😬</InlineAlert>);
+        const cut = mount(<InlineAlert variant="danger" className="foo">😬</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass("foo")).toBe(true);
     });
 
@@ -33,7 +33,7 @@ describe('Inline Alerts', () => {
 
 describe('Standalone Inline Alerts', () => {
     it('should have the standalone class if the standalone prop is set', () => {
-        const cut = mount(<InlineAlert variant="invalid" standalone>😬</InlineAlert>);
+        const cut = mount(<InlineAlert variant="danger" standalone>😬</InlineAlert>);
         expect(cut.find('.rvt-inline-alert').hasClass('rvt-inline-alert--standalone'));
     });
 });

--- a/src/components/Alert/InlineAlert.tsx
+++ b/src/components/Alert/InlineAlert.tsx
@@ -3,7 +3,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 
 import * as Rivet from '../util/Rivet';
-import { validationClass, validationIcon } from '../util/validation'
+import { validationIcon } from '../util/validation'
 
 interface InlineAlertProps {
     /**
@@ -14,7 +14,7 @@ interface InlineAlertProps {
     /**
      * Rivet style for inline validation.
      */
-    variant: 'info' | 'invalid' | 'valid' | 'warning';
+    variant: 'danger' | 'info' | 'success' | 'warning';
 };
 
 const InlineAlert: React.SFC<InlineAlertProps & React.HTMLAttributes<HTMLDivElement>> =
@@ -29,7 +29,7 @@ const InlineAlert: React.SFC<InlineAlertProps & React.HTMLAttributes<HTMLDivElem
         const classes = classNames({
             ['rvt-inline-alert']: true,
             ['rvt-inline-alert--standalone']: standalone,
-            [`rvt-inline-alert--${validationClass(variant)}`]: true
+            [`rvt-inline-alert--${variant}`]: true
         }, className);
         return (
             <div className={classes} {...attrs}>

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -18,7 +18,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
 ```jsx
 <Input type="text"
        name="valid-input"
-       variant="valid"
+       variant="success"
        label="First Name"
        note={<><strong>First Name</strong> is valid</>}
        margin={{bottom: 'md'}} />
@@ -32,7 +32,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
 
 <Input type="text"
        name="error-input"
-       variant="invalid"
+       variant="danger"
        label="Username"
        note={<>The <strong>Username</strong> you entered is taken</>}
        margin={{bottom: 'md'}} />

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -52,7 +52,7 @@ describe('<Input />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
-            const cut = mount(<Input variant="valid" label="Label" note="😎" />);
+            const cut = mount(<Input variant="success" label="Label" note="😎" />);
             expect(cut.find('input').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(false);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
@@ -64,7 +64,7 @@ describe('<Input />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
-            const cut = mount(<Input variant="invalid" label="Label" note="😬"/>);
+            const cut = mount(<Input variant="danger" label="Label" note="😬"/>);
             expect(cut.find('input').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('input').prop("aria-invalid")).toEqual(true);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);

--- a/src/components/Input/Select.md
+++ b/src/components/Input/Select.md
@@ -23,7 +23,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
 ```jsx
 <Select type="text"
        name="select-valid-state"
-       variant="valid"
+       variant="success"
        label="Type"
        note={<> You must pick a <strong>Type</strong> of meat. </>}
        margin={{bottom: 'md'}}>
@@ -49,7 +49,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
 
 <Select type="text"
        name="select-error-state"
-       variant="invalid"
+       variant="danger"
        label="Type"
        note={<> You must pick a <strong>Type</strong> of meat. </>}
        margin={{bottom: 'md'}}>

--- a/src/components/Input/Select.test.tsx
+++ b/src/components/Input/Select.test.tsx
@@ -59,7 +59,7 @@ describe('<Select />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
-            const cut = mount(<Select variant="valid" label="Label" note="😎" />);
+            const cut = mount(<Select variant="success" label="Label" note="😎" />);
             expect(cut.find('select').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(false);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
@@ -71,7 +71,7 @@ describe('<Select />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
-            const cut = mount(<Select variant="invalid" label="Label" note="😬"/>);
+            const cut = mount(<Select variant="danger" label="Label" note="😬"/>);
             expect(cut.find('select').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('select').prop("aria-invalid")).toEqual(true);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);

--- a/src/components/Input/Textarea.md
+++ b/src/components/Input/Textarea.md
@@ -13,7 +13,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
 
 ```jsx
 <Textarea name="textarea-valid" 
-          variant="valid" 
+          variant="success" 
           label="Essay" 
           note={<>Your <strong>Essay</strong> is valid!</>} 
           margin={{bottom: "md"}} />
@@ -25,7 +25,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
           margin={{bottom: "md"}} />
 
 <Textarea name="textarea-invalid" 
-          variant="invalid" 
+          variant="danger" 
           label="Description" 
           note={<>Your <strong>Description</strong> has invalid characters.</>} 
           margin={{bottom: "md"}} />

--- a/src/components/Input/Textarea.test.tsx
+++ b/src/components/Input/Textarea.test.tsx
@@ -48,7 +48,7 @@ describe('<Texarea />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--info")).toBe(true);
         });
         it('valid style', () => { 
-            const cut = mount(<Textarea variant="valid" label="Label" note="😎"/>);
+            const cut = mount(<Textarea variant="success" label="Label" note="😎"/>);
             expect(cut.find('textarea').hasClass("rvt-validation-success")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(false);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--success")).toBe(true);
@@ -60,7 +60,7 @@ describe('<Texarea />', () => {
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--warning")).toBe(true);
         });
         it('invalid style', () => { 
-            const cut = mount(<Textarea variant="invalid" label="Label" note="😬"/>);
+            const cut = mount(<Textarea variant="danger" label="Label" note="😬"/>);
             expect(cut.find('textarea').hasClass("rvt-validation-danger")).toEqual(true);
             expect(cut.find('textarea').prop("aria-invalid")).toEqual(true);
             expect(cut.find('.rvt-inline-alert').hasClass("rvt-inline-alert--danger")).toBe(true);

--- a/src/components/Input/common.tsx
+++ b/src/components/Input/common.tsx
@@ -4,8 +4,6 @@ import * as React from 'react';
 import InlineAlert from '../Alert/InlineAlert';
 import * as Rivet from '../util/Rivet';
 
-import { validationClass } from '../util/validation';
-
 export interface TextProps {
     /** The label for the input */
     label: string;
@@ -14,12 +12,12 @@ export interface TextProps {
     /** An optional note that will be displayed below the input */
     note?: React.ReactNode;
     /** Rivet style for inline validation */
-    variant?: 'info' | 'invalid' | 'valid' | 'warning';
+    variant?: 'danger' | 'info' | 'success' | 'warning';
 }
 
 const inputClassName = (variant) => 
     variant
-    ? `rvt-validation-${validationClass(variant)}`
+    ? `rvt-validation-${variant}`
     : '';
 
 const noteFragment = (id : string, variant, note? : React.ReactNode) => 
@@ -35,7 +33,7 @@ export const renderInput =
             id, 
             className: inputClassName(variant), 
             "aria-describedby": note ? noteId : '', 
-            "aria-invalid": variant === 'invalid', 
+            "aria-invalid": variant === 'danger', 
             ...attrs
         }
         return (

--- a/src/components/util/validation.tsx
+++ b/src/components/util/validation.tsx
@@ -1,26 +1,21 @@
 import * as React from 'react';
 import Icon from '../util/RivetIcons';
 
-type ValidationType = 'info' | 'invalid' | 'valid' | 'warning';
+type ValidationType = 'danger' | 'info' | 'success' | 'warning';
 
 const validationDisplayOptions : object = {
+    danger: {
+        icon: <Icon name="error" />
+    },    
     info: {
-        className: 'info',
         icon: <Icon name="info" />
     },
-    valid: {
-        className: 'success',
+    success: {
         icon: <Icon name="success" />
     },
     warning: {
-        className: 'warning',
         icon: <Icon name="warning" />
-    },
-    invalid: {
-        className: 'danger',
-        icon: <Icon name="error" />
     },
 }
 
 export const validationIcon = (validation: ValidationType) =>  validationDisplayOptions[validation].icon;
-export const validationClass = (validation : ValidationType) => validationDisplayOptions[validation].className;


### PR DESCRIPTION
The variant options for `InlineAlert` as well as for the various input components that use `InlineAlert`, were still using the `valid` and `invalid` variants, that are no longer used in Rivet and also inconsistent with other components. 
This also removes the `validationClass()` method from `validation.tsx` as the translation is no longer necessary.