### PR TITLE
fix(File): tsx files were not finding correct path to this module

### DIFF
--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -1,6 +1,7 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
-import { rivetize, shortuid } from '../util/Rivet';
+
+import * as Rivet from '../util/Rivet';
 import Icon from '../util/RivetIcons';
 
 interface FileProps {
@@ -14,7 +15,7 @@ const initialState = { files: '' }
 type FileState = Readonly<typeof initialState>
 
 const FileInput: React.SFC<FileProps & React.HTMLAttributes<HTMLInputElement>> = 
-({ className, fileName, id = shortuid(), label = 'Upload a file', ...attrs }) => (
+({ className, fileName, id = Rivet.shortuid(), label = 'Upload a file', ...attrs }) => (
     <div className={classNames('rvt-file', className)}>
         <input {...attrs} type="file" id={id} aria-describedby={id + "-file-description"} />
         <label htmlFor={id} className="rvt-button">
@@ -52,5 +53,5 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
 
 }
 
-export default rivetize(File);
+export default Rivet.rivetize(File);
 export { File as UnwrappedFile, FileInput, FileState };


### PR DESCRIPTION
<img width="2057" alt="screen shot 2018-10-26 at 3 06 06 pm" src="https://user-images.githubusercontent.com/1017119/47593135-74be7b00-d933-11e8-91a6-aae0bbf5c457.png">

You would get a compiler error when trying to import `rivet-react@0.6.1` into a typescript project
```Failed to compile.

/app/node_modules/rivet-react/build/dist/components/File/File.d.ts
(18,110): Cannot find module '../src/components/util/Rivet'.```