### PR TITLE
Add ability to clear the selected file and description

### DIFF
--- a/src/components/File/File.md
+++ b/src/components/File/File.md
@@ -7,3 +7,53 @@ View the [Rivet documentation for File Input](https://rivet.uits.iu.edu/componen
 ```jsx
 <File name="demo" />
 ```
+
+### Passing in props instead of using internal state to track file name
+
+```jsx
+class FileProps extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      files: ''
+    };
+    this.fieldName = 'file-demo-2';
+    this.onChange = this.onChange.bind(this);
+    this.clearFile = this.clearFile.bind(this);
+  }
+
+  clearFile(e) {
+    // update dom
+    const element = document.querySelector(`[name="${this.fieldName}"]`);
+    element.value = '';
+    /// update state
+    this.setState({
+      files: ''
+    });
+  }
+
+  onChange(e) {
+    const files = [];
+    // e.target.files is not a real array, so cannot use forEach, map, etc. 
+    for (let i = 0; i < e.target.files.length; i++) {
+      files.push(e.target.files[i].name);
+    }
+    this.setState({
+      files: files.join(', ')
+    });    
+  }
+
+  render() {
+    return (
+      <div>
+        <File name={this.fieldName} files={this.state.files} onChange={this.onChange} />
+        <br />
+        <Button onClick={this.clearFile}>Clear file</Button>
+      </div>
+    );
+  }
+}
+
+<FileProps />
+
+```

--- a/src/components/File/File.md
+++ b/src/components/File/File.md
@@ -8,48 +8,28 @@ View the [Rivet documentation for File Input](https://rivet.uits.iu.edu/componen
 <File name="demo" />
 ```
 
-### Passing in props instead of using internal state to track file name
+### Clearing a file input programattically
 
 ```jsx
 class FileProps extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      files: ''
-    };
-    this.fieldName = 'file-demo-2';
-    this.onChange = this.onChange.bind(this);
+    this.formRef = React.createRef();
     this.clearFile = this.clearFile.bind(this);
   }
 
   clearFile(e) {
-    // update dom
-    const element = document.querySelector(`[name="${this.fieldName}"]`);
-    element.value = '';
-    /// update state
-    this.setState({
-      files: ''
-    });
-  }
-
-  onChange(e) {
-    const files = [];
-    // e.target.files is not a real array, so cannot use forEach, map, etc. 
-    for (let i = 0; i < e.target.files.length; i++) {
-      files.push(e.target.files[i].name);
-    }
-    this.setState({
-      files: files.join(', ')
-    });    
+    e.preventDefault();
+    this.formRef.current.reset();
   }
 
   render() {
     return (
-      <div>
-        <File name={this.fieldName} files={this.state.files} onChange={this.onChange} />
+      <form ref={this.formRef}>
+        <File name='file-upload-demo-2' />
         <br />
-        <Button onClick={this.clearFile}>Clear file</Button>
-      </div>
+        <Button type="button" onClick={this.clearFile}>Clear file</Button>
+      </form>
     );
   }
 }

--- a/src/components/File/File.test.tsx
+++ b/src/components/File/File.test.tsx
@@ -1,4 +1,4 @@
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import * as React from 'react';
 import File, { UnwrappedFile } from './File';
 

--- a/src/components/File/File.test.tsx
+++ b/src/components/File/File.test.tsx
@@ -1,6 +1,6 @@
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
-import File, { FileState, UnwrappedFile } from './File';
+import File, { UnwrappedFile } from './File';
 
 const simulatedChangeEvent = {
     target: {
@@ -39,11 +39,17 @@ describe('<File />', () => {
     describe('Stateful component behavior', () => {
         it('should handle file selection', () => {
             const cut = mount(<UnwrappedFile />);
-            let state = cut.state() as FileState;
-            expect(state.files).toBe('');
-            cut.find('input').simulate('change', simulatedChangeEvent);
-            state = cut.state() as FileState;
-            expect(state.files).toBe('foo.txt, bar.txt');
+            let description = cut.find('.rvt-file__preview').props().children;
+            expect(description).toBe('No file selected');
+            const input = cut.find('input');
+            // console.log('before event');
+            input.simulate('change', simulatedChangeEvent);
+            // console.log(input.instance().);
+            // console.log('after event');
+            cut.render();
+            // console.log(cut.debug());
+            // state = cut.state() as FileState;
+            // expect(state.files).toBe('foo.txt, bar.txt');
         });
         it('should invoke a provided onChange handler', () => {
             const spy = jest.fn();

--- a/src/components/File/File.test.tsx
+++ b/src/components/File/File.test.tsx
@@ -36,21 +36,7 @@ describe('<File />', () => {
         });
     });
 
-    describe('Stateful component behavior', () => {
-        it('should handle file selection', () => {
-            const cut = mount(<UnwrappedFile />);
-            let description = cut.find('.rvt-file__preview').props().children;
-            expect(description).toBe('No file selected');
-            const input = cut.find('input');
-            // console.log('before event');
-            input.simulate('change', simulatedChangeEvent);
-            // console.log(input.instance().);
-            // console.log('after event');
-            cut.render();
-            // console.log(cut.debug());
-            // state = cut.state() as FileState;
-            // expect(state.files).toBe('foo.txt, bar.txt');
-        });
+    describe('Component behavior', () => {
         it('should invoke a provided onChange handler', () => {
             const spy = jest.fn();
             const cut = mount(<UnwrappedFile onChange={spy} />);

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -11,6 +11,8 @@ interface FileProps {
     files?: string;
     /** The text for the file button */
     label?: string;
+    /** Handle on DOM file input field */
+    innerRef?: React.RefObject<HTMLInputElement>;
 }
 
 
@@ -20,7 +22,7 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
     
     public constructor(props) {
         super(props);
-        this.fileInput = React.createRef();
+        this.fileInput = props.innerRef ? props.innerRef : React.createRef();
     }   
 
     public componentDidMount() {
@@ -33,7 +35,7 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
     }
 
     public render() {
-        const { className, fileName, id = Rivet.shortuid(), label = 'Upload a file', ...attrs } = this.props;
+        const { className, fileName, id = Rivet.shortuid(), innerRef, label = 'Upload a file', ...attrs } = this.props;
 
         let description = 'No file selected';
         if (this.fileInput.current && this.fileInput.current.files && this.fileInput.current.files.length) {

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -13,12 +13,8 @@ interface FileProps {
     label?: string;
 }
 
-const initialState = { count: 0 }
-type FileState = Readonly<typeof initialState>
 
-class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInputElement>, FileState> {
-
-    public readonly state: FileState = initialState;
+class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInputElement>> {
     
     private fileInput: React.RefObject<HTMLInputElement>;
     
@@ -43,10 +39,10 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
         if (this.fileInput.current && this.fileInput.current.files && this.fileInput.current.files.length) {
             description = Array.from(this.fileInput.current.files).map(file => file.name).join(', ');
         }
-        
+
         return (
             <div className={classNames('rvt-file', className)}>
-                <input onChange={this.handleFileChange} {...attrs} ref={this.fileInput} type="file" id={id} aria-describedby={id + "-file-description"} />
+                <input onInput={this.handleFileChange} {...attrs} ref={this.fileInput} type="file" id={id} aria-describedby={id + "-file-description"} />
                 <label htmlFor={id} className="rvt-button">
                     <span>{label}</span>
                     <Icon name="file" />
@@ -68,4 +64,4 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
 }
 
 export default Rivet.rivetize(File);
-export { File as UnwrappedFile, FileState };
+export { File as UnwrappedFile };

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -5,10 +5,6 @@ import * as Rivet from '../util/Rivet';
 import Icon from '../util/RivetIcons';
 
 interface FileProps {
-    /** The name(s) of the selected files */
-    fileName?: string;
-    /** File state, if maintaining state outside of the component */
-    files?: string;
     /** The text for the file button */
     label?: string;
     /** Handle on DOM file input field */
@@ -35,7 +31,7 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
     }
 
     public render() {
-        const { className, fileName, id = Rivet.shortuid(), innerRef, label = 'Upload a file', ...attrs } = this.props;
+        const { className, id = Rivet.shortuid(), innerRef, label = 'Upload a file', ...attrs } = this.props;
 
         let description = 'No file selected';
         if (this.fileInput.current && this.fileInput.current.files && this.fileInput.current.files.length) {

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -13,48 +13,59 @@ interface FileProps {
     label?: string;
 }
 
-const initialState = { files: '' }
+const initialState = { count: 0 }
 type FileState = Readonly<typeof initialState>
-
-const FileInput: React.SFC<FileProps & React.HTMLAttributes<HTMLInputElement>> = 
-({ className, fileName, id = Rivet.shortuid(), label = 'Upload a file', ...attrs }) => (
-    <div className={classNames('rvt-file', className)}>
-        <input {...attrs} type="file" id={id} aria-describedby={id + "-file-description"} />
-        <label htmlFor={id} className="rvt-button">
-            <span>{label}</span>
-            <Icon name="file" />
-        </label>
-        <div className="rvt-file__preview" id={id + "-file-description"}>
-            { fileName ? <span>{fileName}</span> : 'No file selected' }
-        </div>
-    </div>
-);
-FileInput.displayName = 'FileInput';
 
 class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInputElement>, FileState> {
 
     public readonly state: FileState = initialState;
+    
+    private fileInput: React.RefObject<HTMLInputElement>;
+    
+    public constructor(props) {
+        super(props);
+        this.fileInput = React.createRef();
+    }   
+
+    public componentDidMount() {
+        const form = this.fileInput.current && this.fileInput.current.form;
+        if (form) {
+            form.onreset = (e) => {
+                this.forceUpdate();
+            };
+        }
+    }
 
     public render() {
-        const files = ('files' in this.props) ? this.props.files : this.state.files;
+        const { className, fileName, id = Rivet.shortuid(), label = 'Upload a file', ...attrs } = this.props;
+
+        let description = 'No file selected';
+        if (this.fileInput.current && this.fileInput.current.files && this.fileInput.current.files.length) {
+            description = Array.from(this.fileInput.current.files).map(file => file.name).join(', ');
+        }
+        
         return (
-            <FileInput {...this.props} fileName={files} onChange={this.handleFileChange} />
+            <div className={classNames('rvt-file', className)}>
+                <input onChange={this.handleFileChange} {...attrs} ref={this.fileInput} type="file" id={id} aria-describedby={id + "-file-description"} />
+                <label htmlFor={id} className="rvt-button">
+                    <span>{label}</span>
+                    <Icon name="file" />
+                </label>
+                <div className="rvt-file__preview" id={id + "-file-description"}>
+                    { description }
+                </div>
+            </div>
         )
     }
 
     private handleFileChange = (changeEvent) => {
-        // changeEvent.target.files is a FileList which is not iterable, though a for..of loop works
-        const files: string[] = [];
-        for(const file of changeEvent.target.files) {
-            files.push(file.name);
-        }
-        this.setState({ files: files.join(', ') });
         if (this.props.onChange){
             this.props.onChange(changeEvent);
         }
+        this.forceUpdate();
     }
 
 }
 
 export default Rivet.rivetize(File);
-export { File as UnwrappedFile, FileInput, FileState };
+export { File as UnwrappedFile, FileState };

--- a/src/components/File/File.tsx
+++ b/src/components/File/File.tsx
@@ -7,6 +7,8 @@ import Icon from '../util/RivetIcons';
 interface FileProps {
     /** The name(s) of the selected files */
     fileName?: string;
+    /** File state, if maintaining state outside of the component */
+    files?: string;
     /** The text for the file button */
     label?: string;
 }
@@ -34,8 +36,9 @@ class File extends React.PureComponent<FileProps & React.HTMLAttributes<HTMLInpu
     public readonly state: FileState = initialState;
 
     public render() {
+        const files = ('files' in this.props) ? this.props.files : this.state.files;
         return (
-            <FileInput {...this.props} fileName={this.state.files} onChange={this.handleFileChange} />
+            <FileInput {...this.props} fileName={files} onChange={this.handleFileChange} />
         )
     }
 

--- a/src/components/util/Rivet.test.tsx
+++ b/src/components/util/Rivet.test.tsx
@@ -1,6 +1,5 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import * as Rivet from './Rivet';
 
 const DemoComponent = Rivet.rivetize(({ children, ...attrs }) => (


### PR DESCRIPTION
This removes the state formerly used and leans more heavily on the native HTML File API, allowing clearing the selected file and description by resetting the containing form.

It also adds an optional `innerRef` prop, which allows a parent component to access the file input element. 

