### PR TITLE
feat(Accessibility): Use Full URL in "Skip to Content" Link Location

### DIFF
--- a/src/components/Header/Header.test.tsx
+++ b/src/components/Header/Header.test.tsx
@@ -31,6 +31,11 @@ describe('<Header />', () => {
         it('should not render the header navigation when it is not provided', () => {
             expect(cut.find('HeaderNavigation')).toHaveLength(0);
         });
+        it('should render the skip to content link with the full URL', () => {
+            const skipLink = cut.find('.rvt-skip-link')
+            expect(skipLink).toHaveLength(1);
+            expect(skipLink.props().href).toEqual(`${document.URL}#main-content`);
+        })
     });
 
     describe('Including header navigation', () => {

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -25,7 +25,7 @@ const HeaderComponent: React.SFC<HeaderProps & React.HTMLAttributes<HTMLDivEleme
     const navigation = findFirstChildOfType(children, Navigation.displayName);
     return (
         <header {...attrs} className={classNames(componentClass, className)} role="banner">
-            <a className="rvt-skip-link" href="#main-content">Skip to content</a>
+            <a className="rvt-skip-link" href={`${document.URL}#main-content`}>Skip to content</a>
             <div className="rvt-header__trident">
                 <Icon name="trident-header" />
             </div>


### PR DESCRIPTION
The skip to content link will not currently work if a base tag is present (it will always return the user to `/#main-content`). Adding the full URL allows it to preserve the user's page in the application.

closes #193 