### PR TITLE
Feature/toggle dropdown click inside

### DIFF
--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -34,13 +34,11 @@ By default the dropdown menu is vertically aligned with the left edge of the dro
 
 ### Toggle On Click Inside Modifier
 
-By default the dropdown menu will no close when an item within the dropdown is clicked. Set the 'toggleDropdownOnClickInside' option to true to specify the dropdown should be closed in this case.
+By default the dropdown menu will not close when an item within the dropdown is clicked. Set the 'toggleDropdownOnClickInside' option to true to specify the dropdown should be closed in this case.
 
 ```jsx
-<Dropdown toggleDropdownOnClickInside={true}>
-    <a href="#">Item one</a>
-    <a href="#">Item two</a>
-    <a href="#" aria-current="page">Item three</a>
-    <a href="#">Item four</a>
+<Dropdown label="Toggle On Click" toggleDropdownOnClickInside>
+    <Button variant="plain">Item one</Button>
+    <Button variant="plain">Item two</Button>
 </Dropdown>
 ```

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -39,6 +39,6 @@ By default the dropdown menu will not close when an item within the dropdown is 
 ```jsx
 <Dropdown label="Toggle On Click" toggleDropdownOnClickInside>
     <Button onClick={() => alert('Clicked Item one')}>Item one</Button>
-    <Button onClick={() => alert('Clicked Item one')}>Item two</Button>
+    <Button onClick={() => alert('Clicked Item two')}>Item two</Button>
 </Dropdown>
 ```

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -31,3 +31,16 @@ By default the dropdown menu is vertically aligned with the left edge of the dro
     <a href="#">Item four</a>
 </Dropdown>
 ```
+
+### Toggle On Click Inside Modifier
+
+By default the dropdown menu will no close when an item within the dropdown is clicked. Set the 'toggleDropdownOnClickInside' option to true to specify the dropdown should be closed in this case.
+
+```jsx
+<Dropdown toggleDropdownOnClickInside={true}>
+    <a href="#">Item one</a>
+    <a href="#">Item two</a>
+    <a href="#" aria-current="page">Item three</a>
+    <a href="#">Item four</a>
+</Dropdown>
+```

--- a/src/components/Dropdown/Dropdown.md
+++ b/src/components/Dropdown/Dropdown.md
@@ -38,7 +38,7 @@ By default the dropdown menu will not close when an item within the dropdown is 
 
 ```jsx
 <Dropdown label="Toggle On Click" toggleDropdownOnClickInside>
-    <Button variant="plain">Item one</Button>
-    <Button variant="plain">Item two</Button>
+    <Button onClick={() => alert('Clicked Item one')}>Item one</Button>
+    <Button onClick={() => alert('Clicked Item one')}>Item two</Button>
 </Dropdown>
 ```

--- a/src/components/Dropdown/Dropdown.test.jsx
+++ b/src/components/Dropdown/Dropdown.test.jsx
@@ -118,6 +118,39 @@ describe('<Dropdown />', () => {
         });
     });
 
+    describe('Toggle behavior click inside override', () => {
+
+        let cut;
+
+        const expectDropdownMenuIsOpen = () => {
+            expect(document.getElementsByClassName('rvt-dropdown__menu')).toHaveLength(1);
+        }
+
+        const expectDropdownMenuIsClosed = () => {
+            expect(document.getElementsByClassName('rvt-dropdown__menu')).toHaveLength(0);
+        }
+
+        const clickToggleButton = () => {
+            document.getElementsByTagName('button')[0].click();
+        }
+
+        beforeEach(() => {
+            ReactDOM.render(
+                <Dropdown toggleDropdownOnClickInside={true}>
+                    <a href="#">Hello, world!</a>
+                </Dropdown>, root
+            );
+        });
+
+        it('should toggle the menu when clicking inside the menu', () => {
+            expectDropdownMenuIsClosed();
+            clickToggleButton();
+            expectDropdownMenuIsOpen();
+            document.getElementsByTagName('a')[0].click();
+            expectDropdownMenuIsClosed();
+        });
+    });
+
     describe('Event handler registration', () => {
         
         afterEach(() => {

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -25,6 +25,8 @@ interface DropdownProps extends ButtonProps {
      * Optional CSS classes which will be applied to the dropdown menu
      */
     menuClass?: string;
+    /** Optional flag to toggle the dropdown open state when a click is done within the dropdown contents */
+    toggleDropdownOnClickInside?: boolean;
 }
 
 const initialState = { open: false }
@@ -59,7 +61,7 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
     }
 
     public render() {
-        const { align, children, className, label, menuClass, ...attrs } = this.props;
+        const { align, children, className, label, menuClass, toggleDropdownOnClickInside, ...attrs } = this.props;
         const menuClasses = classNames({
             ['rvt-dropdown__menu']: true,
             [`rvt-dropdown__menu--${align}`]: !!align
@@ -101,7 +103,7 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
             return false;
         }
 
-        if (event.targets(ReactDOM.findDOMNode(this)) && (!event.isKeyEvent() || event.isTabKeyPress())) {
+        if (event.targets(ReactDOM.findDOMNode(this)) && !this.props.toggleDropdownOnClickInside && (!event.isKeyEvent() || event.isTabKeyPress())) {
             // If the user clicks, touches or tabs inside the dropdown do not close the menu
             return false;
         }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -103,7 +103,8 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
             return false;
         }
 
-        if (event.targets(ReactDOM.findDOMNode(this)) && !this.props.toggleDropdownOnClickInside && (!event.isKeyEvent() || event.isTabKeyPress())) {
+        const preventToggleOnInsideClick = !event.isKeyEvent() && !this.props.toggleDropdownOnClickInside;
+        if (event.targets(ReactDOM.findDOMNode(this)) && (preventToggleOnInsideClick || event.isTabKeyPress())) {
             // If the user clicks, touches or tabs inside the dropdown do not close the menu
             return false;
         }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -61,7 +61,7 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
     }
 
     public render() {
-        const { align, children, className, label, menuClass, toggleDropdownOnClickInside, ...attrs } = this.props;
+        const { align, children, className, label, menuClass, toggleDropdownOnClickInside = false, ...attrs } = this.props;
         const menuClasses = classNames({
             ['rvt-dropdown__menu']: true,
             [`rvt-dropdown__menu--${align}`]: !!align

--- a/src/components/Dropdown/DropdownEvent.ts
+++ b/src/components/Dropdown/DropdownEvent.ts
@@ -7,7 +7,27 @@ import AbstractUserActionEvent from '../util/AbstractUserActionEvent';
 export default class DropdownEvent extends AbstractUserActionEvent  {
 
     public static handler = (callback) => {
-        return AbstractUserActionEvent.handler(callback, DropdownEvent);
+        const eventHandler = (event) => {
+            callback(new DropdownEvent(event));
+        };
+        return ({
+            register: () => {
+                ['click'].forEach(event =>
+                    document.addEventListener(event, eventHandler, false)
+                );
+                ['touchstart', 'keyup'].forEach(event =>
+                    document.addEventListener(event, eventHandler, true)
+                );
+            },
+            deregister: () => {
+                ['click'].forEach(event =>
+                    document.removeEventListener(event, eventHandler, false)
+                );
+                ['touchstart', 'keyup'].forEach(event =>
+                    document.removeEventListener(event, eventHandler, true)
+                );
+            }
+        });
     }
 
     public isUnhandledKeyPress() : boolean {


### PR DESCRIPTION
This fixes a problem with the feature in that the onClick for dropdown children was not getting invoked because the click event was getting captured by the DropdownEvent listener