### PR TITLE
Add property to Dropdown component to not render role=menu

### DIFF
--- a/src/components/Dropdown/Dropdown.test.jsx
+++ b/src/components/Dropdown/Dropdown.test.jsx
@@ -256,4 +256,46 @@ describe('<Dropdown />', () => {
             expect(UnwrappedDropdown.prototype.toggleDropdown).toHaveBeenCalledTimes(1);
         });    
     });
+
+    describe('Menu Role Behavior', () => {
+
+            it('role=menu should render by default', () => {
+                let cut = mount(<Dropdown>
+                                <a href="#">Hello, world!</a>
+                            </Dropdown>, { attachTo: root });
+                cut.find('button').simulate("click");
+
+                expect(cut.find( 'div.rvt-dropdown__menu[role="menu"]' )).toHaveLength(1);
+
+            });
+
+            it('excludeMenuRole=true should not render the role=menu', () => {
+                let cut = mount(<Dropdown excludeMenuRole={true}>
+                                <a href="#">Hello, world!</a>
+                            </Dropdown>, { attachTo: root });
+                cut.find('button').simulate("click");
+
+                expect(cut.find( 'div.rvt-dropdown__menu[role="menu"]' )).toHaveLength(0);
+
+            });
+
+            it('excludeMenuRole=false should render the role=menu', () => {
+                let cut = mount(<Dropdown excludeMenuRole={false}>
+                                <a href="#">Hello, world!</a>
+                            </Dropdown>, { attachTo: root });
+                cut.find('button').simulate("click");
+
+                expect(cut.find( 'div.rvt-dropdown__menu[role="menu"]' )).toHaveLength(1);
+            });
+
+            it('invalid value for excludeMenuRole should render the role=menu', () => {
+                let cut = mount(<Dropdown excludeMenuRole="bogus">
+                                <a href="#">Hello, world!</a>
+                            </Dropdown>, { attachTo: root });
+                cut.find('button').simulate("click");
+
+                expect(cut.find( 'div.rvt-dropdown__menu[role="menu"]' )).toHaveLength(1);
+            });
+
+        });
 });

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -13,7 +13,7 @@ interface DropdownProps extends ButtonProps {
     /** Optional Rivet style: alignment of the dropdown menu items relative to the edge of the dropdown button. */
     align?: 'right';
     /**
-     * Optional text which appears on the dropdown toggle button. The label
+     * Optional text which appears on the dropdown toggle button. The label 
      * should always be provided with a standalone dropdown, however the label
      * can be omitted if the dropdown is part of a SegmentedButton.
      * @see https://rivet.uits.iu.edu/components/navigation/dropdown/
@@ -81,7 +81,7 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
                     { label && <span className="rvt-dropdown__toggle-text">{label}</span> }
                     <Icon name="caret-down" />
                 </Button>
-
+    
                 {this.state.open &&
                     <div className={menuClasses} aria-hidden={!this.state.open} role={(excludeMenuRole && excludeMenuRole === true) ? undefined : 'menu'}>
                         {children}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -27,8 +27,9 @@ interface DropdownProps extends ButtonProps {
     /** Optional flag to toggle the dropdown open state when a click is done within the dropdown contents */
     toggleDropdownOnClickInside?: boolean;
 
-    /** Optional flag to not render the role=menu on the Dropdown. This has accessibility implications, so make sure
-     *  this is the most accessible choice for your scenario before using this flag
+    /** Optional flag to NOT render the role="menu" on the Dropdown. This has accessibility implications, so
+     *  make sure this is the most accessible choice for your scenario before using this flag.
+     *  Default will include role="menu" in the rendered html
      */
     excludeMenuRole?: boolean;
 }

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -13,7 +13,7 @@ interface DropdownProps extends ButtonProps {
     /** Optional Rivet style: alignment of the dropdown menu items relative to the edge of the dropdown button. */
     align?: 'right';
     /**
-     * Optional text which appears on the dropdown toggle button. The label 
+     * Optional text which appears on the dropdown toggle button. The label
      * should always be provided with a standalone dropdown, however the label
      * can be omitted if the dropdown is part of a SegmentedButton.
      * @see https://rivet.uits.iu.edu/components/navigation/dropdown/
@@ -26,6 +26,11 @@ interface DropdownProps extends ButtonProps {
     menuClass?: string;
     /** Optional flag to toggle the dropdown open state when a click is done within the dropdown contents */
     toggleDropdownOnClickInside?: boolean;
+
+    /** Optional flag to not render the role=menu on the Dropdown. This has accessibility implications, so make sure
+     *  this is the most accessible choice for your scenario before using this flag
+     */
+    excludeMenuRole?: boolean;
 }
 
 const initialState = { open: false }
@@ -64,7 +69,7 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
     public render() {
         const {
             toggleDropdownOnClickInside = false, // eslint-disable-line @typescript-eslint/no-unused-vars
-            align, children, className, label, menuClass, ...attrs } = this.props;
+            align, children, className, label, menuClass, excludeMenuRole = false, ...attrs } = this.props;
         const menuClasses = classNames({
             'rvt-dropdown__menu': true,
             [`rvt-dropdown__menu--${align}`]: !!align
@@ -75,9 +80,9 @@ export class Dropdown extends React.PureComponent<DropdownProps & React.HTMLAttr
                     { label && <span className="rvt-dropdown__toggle-text">{label}</span> }
                     <Icon name="caret-down" />
                 </Button>
-    
+
                 {this.state.open &&
-                    <div className={menuClasses} aria-hidden={!this.state.open} role="menu">
+                    <div className={menuClasses} aria-hidden={!this.state.open} role={(excludeMenuRole && excludeMenuRole === true) ? undefined : 'menu'}>
                         {children}
                     </div>
                 }


### PR DESCRIPTION
We use the Dropdown component in two of our tools to display/hide options for filtering the current view (LMS tools for Canvas). After going through an accessibility review, the recommendation is that we should not be using the role=menu attribute for our use case. It would be helpful if the Dropdown component had an additional property to optionally render the Dropdown without this accessibility role. I will provide a pull request.

https://github.com/indiana-university/rivet-react/issues/254