### PR TITLE
feat: ESIMW-2399: Fix Alert accessibility issue

### DIFF
--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -20,7 +20,17 @@ describe('<Alert />', () => {
         it('should include title', () => {
             const cut = mount(<Alert variant="info" title="Alert Title" />);
             expect(cut.find('.rvt-alert__title').text()).toEqual("Alert Title");
-        });      
+        });   
+        it('ahould have and aria-labelledby if there is a title', () => {
+            const cut = mount(<Alert variant="info" title="Alert Title" />);
+            const div = cut.find('.rvt-alert');
+            expect(div.props()['aria-labelledby']).toBeDefined();
+        }); 
+        it('ahould not have and aria-labelledby if there is no title', () => {
+            const cut = mount(<Alert variant="info" />);
+            const div = cut.find('.rvt-alert');
+            expect(div.props()['aria-labelledby']).toBeUndefined();
+        });   
         it('should apply the id', () => {
             const cut = mount(<Alert variant="info" id="the_id" />);
             expect(cut.prop('id')).toEqual("the_id");

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -49,8 +49,10 @@ const Alert : React.SFC<AlertProps & React.HTMLAttributes<HTMLDivElement>> =
     
     const classes = classNames('rvt-alert', `rvt-alert--${variant}`, className);
 
+    const ariaProps = title ? { 'aria-labelledby': titleId } : {};
+
     return isOpen 
-        ? <div id={id} className={classes} role='alertdialog' aria-labelledby={titleId} {...attrs} >
+        ? <div id={id} className={classes} role='alertdialog' {...ariaProps} {...attrs} >
                 {headerFragment()}
                 <p className='rvt-alert__message'>{children}</p>
                 {dismissFragment()}


### PR DESCRIPTION
The `Alert` component has an optional title prop. If this is provided, a title header tag is created with a generated id and `aria-labelledby` references this id in the parent. However, this prop was being added to the parent even when there was no title, creating a reference to an id that was not in the dom.