### PR TITLE
Build Input (Input, Textarea, Select) Components

### DIFF
--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import * as React from "react";
+import * as Rivet from "../util/Rivet";
+import { propTypes, renderInput } from "./common";
+
+const Input = renderInput("input");
+
+Input.displayName = "Input";
+Input.propTypes = propTypes;
+
+export default Rivet.rivetize(Input);

--- a/src/components/Input/Input.jsx
+++ b/src/components/Input/Input.jsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import * as Rivet from "../util/Rivet";
 import { propTypes, renderInput } from "./common";
 
-const Input = renderInput("input");
+const Input = (props) => <>{renderInput("input", props)}</>;
 
 Input.displayName = "Input";
 Input.propTypes = propTypes;

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -1,0 +1,50 @@
+Text inputs are the basic building blocks forms. They allow users to enter various types of data into web-based forms.
+
+View the [Rivet documentation for Text Inputs](https://rivet.uits.iu.edu/components/forms/text-input/).
+
+### Text input example
+
+Use the `note` property to provide contextual information to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Input type="text" name="text-demo" label="Text Input" note="This is a note." margin={{ bottom: 'md' }} />
+<Input type="text" name="text-demo-disabled" label="Text Input (Disabled)" disabled />
+```
+<!-- prettier-ignore-end -->
+
+### Inline Validation
+
+Use the `variant` property along with a `note` to provide validation feedback to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Input type="text"
+       name="valid-input"
+       variant="success"
+       label="First Name"
+       note={<><strong>First Name</strong> is valid</>}
+       margin={{bottom: 'md'}} />
+
+<Input type="text"
+       name="warning-input"
+       variant="warning"
+       label="Password"
+       note={<>Your <strong>Password</strong> is weak</>}
+       margin={{bottom: 'md'}} />
+
+<Input type="text"
+       name="error-input"
+       variant="danger"
+       label="Username"
+       note={<>The <strong>Username</strong> you entered is taken</>}
+       margin={{bottom: 'md'}} />
+
+<Input type="text"
+       name="info-input"
+       variant="info"
+       label="Description"
+       note={<>The <strong>Description</strong> tells users more about this stuff.</>}
+       margin={{bottom: 'md'}} />
+```
+<!-- prettier-ignore-end -->

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -8,7 +8,7 @@ Use the `note` property to provide contextual information to the user.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Input type="text" name="text-demo" label="Text Input" note="This is a note." margin={{ bottom: 'md' }} />
+<Input type="text" name="text-demo" label="Text Input" note="This is a note." />
 <Input type="text" name="text-demo-disabled" label="Text Input (Disabled)" disabled />
 ```
 <!-- prettier-ignore-end -->
@@ -23,28 +23,24 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="valid-input"
        variant="success"
        label="First Name"
-       note={<><strong>First Name</strong> is valid</>}
-       margin={{bottom: 'md'}} />
+       note={<><strong>First Name</strong> is valid</>} />
 
 <Input type="text"
        name="warning-input"
        variant="warning"
        label="Password"
-       note={<>Your <strong>Password</strong> is weak</>}
-       margin={{bottom: 'md'}} />
+       note={<>Your <strong>Password</strong> is weak</>} />
 
 <Input type="text"
        name="error-input"
        variant="danger"
        label="Username"
-       note={<>The <strong>Username</strong> you entered is taken</>}
-       margin={{bottom: 'md'}} />
+       note={<>The <strong>Username</strong> you entered is taken</>} />
 
 <Input type="text"
        name="info-input"
        variant="info"
        label="Description"
-       note={<>The <strong>Description</strong> tells users more about this stuff.</>}
-       margin={{bottom: 'md'}} />
+       note={<>The <strong>Description</strong> tells users more about this stuff.</>} />
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Input/Input.md
+++ b/src/components/Input/Input.md
@@ -8,7 +8,7 @@ Use the `note` property to provide contextual information to the user.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Input type="text" name="text-demo" label="Text Input" note="This is a note." />
+<Input type="text" name="text-demo" label="Text Input" note="This is a note." margin={{ bottom: 'md' }} />
 <Input type="text" name="text-demo-disabled" label="Text Input (Disabled)" disabled />
 ```
 <!-- prettier-ignore-end -->
@@ -23,24 +23,28 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="valid-input"
        variant="success"
        label="First Name"
-       note={<><strong>First Name</strong> is valid</>} />
+       note={<><strong>First Name</strong> is valid</>}
+       margin={{bottom: 'md'}} />
 
 <Input type="text"
        name="warning-input"
        variant="warning"
        label="Password"
-       note={<>Your <strong>Password</strong> is weak</>} />
+       note={<>Your <strong>Password</strong> is weak</>}
+       margin={{bottom: 'md'}} />
 
 <Input type="text"
        name="error-input"
        variant="danger"
        label="Username"
-       note={<>The <strong>Username</strong> you entered is taken</>} />
+       note={<>The <strong>Username</strong> you entered is taken</>}
+       margin={{bottom: 'md'}} />
 
 <Input type="text"
        name="info-input"
        variant="info"
        label="Description"
-       note={<>The <strong>Description</strong> tells users more about this stuff.</>} />
+       note={<>The <strong>Description</strong> tells users more about this stuff.</>}
+       margin={{bottom: 'md'}} />
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Input/Input.test.jsx
+++ b/src/components/Input/Input.test.jsx
@@ -1,0 +1,127 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import Input from "./Input";
+
+describe("<Input />", () => {
+  describe("Rendering", () => {
+    it("should render without throwing an error", () => {
+      render(<Input label="Label" />);
+      expect(screen.getByRole("textbox", {})).toBeVisible();
+    });
+    it("should have the correct type", () => {
+      render(<Input type="text" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute("type", "text");
+    });
+    it("should render the label", () => {
+      render(<Input label="Label" />);
+      expect(screen.getByText("Label", {})).toBeVisible();
+    });
+    it("should associate the label with the input", () => {
+      render(<Input id="the_id" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute("id", "the_id");
+      expect(screen.getByText("Label", {})).toHaveProperty("htmlFor", "the_id");
+    });
+    it("should apply custom class", () => {
+      render(<Input className="my-class" label="Label" />);
+      expect(screen.getByRole("textbox", {}).closest("div")).toHaveClass(
+        "my-class"
+      );
+    });
+    it("should apply sr-only class to label", () => {
+      render(<Input label="Label" labelVisibility="screen-reader-only" />);
+      expect(screen.getByText("Label", {})).toHaveClass("rvt-sr-only");
+    });
+  });
+  describe("Notes", () => {
+    it("should apply the note", () => {
+      render(<Input note="Note" label="Label" />);
+      expect(screen.getByText("Note", {})).toBeVisible();
+      expect(screen.getByText("Note", {})).toContainHTML("small");
+    });
+    it("should associate the input with the note", () => {
+      render(<Input id="the_id" note="Note" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-describedby",
+        "the_id_note"
+      );
+    });
+    it("should not apply the aria-describedby attribute when no note is present", () => {
+      render(<Input id="the_id" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-describedby",
+        ""
+      );
+    });
+  });
+  describe("Inline Alerts", () => {
+    it("info style", () => {
+      render(<Input variant="info" label="Label" note="🤔" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-info"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--info"
+      );
+    });
+    it("valid style", () => {
+      render(<Input variant="success" label="Label" note="😎" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-success"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--success"
+      );
+    });
+    it("warning style", () => {
+      render(<Input variant="warning" label="Label" note="🤨" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-warning"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--warning"
+      );
+    });
+    it("invalid style", () => {
+      render(<Input variant="danger" label="Label" note="😬" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-danger"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "true"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--danger"
+      );
+    });
+  });
+});

--- a/src/components/Input/Select.jsx
+++ b/src/components/Input/Select.jsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import * as Rivet from "../util/Rivet";
 import { propTypes, renderInput } from "./common";
 
-const Select = renderInput("select");
+const Select = (props) => <>{renderInput("select", props)}</>;
 
 Select.displayName = "Select";
 Select.propTypes = propTypes;

--- a/src/components/Input/Select.jsx
+++ b/src/components/Input/Select.jsx
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import * as React from "react";
+import * as Rivet from "../util/Rivet";
+import { propTypes, renderInput } from "./common";
+
+const Select = renderInput("select");
+
+Select.displayName = "Select";
+Select.propTypes = propTypes;
+
+export default Rivet.rivetize(Select);

--- a/src/components/Input/Select.md
+++ b/src/components/Input/Select.md
@@ -13,7 +13,6 @@ Use the `note` property to provide contextual information to the user.
   name="text-demo"
   label="Select Input"
   note="This is a note."
-  margin={{ bottom: "md" }}
 >
   <option value="">Choose an option...</option>
   <option value="Option One">Option One</option>
@@ -34,8 +33,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-valid-state"
        variant="success"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}
-       margin={{bottom: 'md'}}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -47,8 +45,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-warning-state"
        variant="warning"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}
-       margin={{bottom: 'md'}}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -60,8 +57,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-error-state"
        variant="danger"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}
-       margin={{bottom: 'md'}}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -73,8 +69,7 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-info-state"
        variant="info"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}
-       margin={{bottom: 'md'}}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>

--- a/src/components/Input/Select.md
+++ b/src/components/Input/Select.md
@@ -1,0 +1,85 @@
+The select element creates a dropdown that allows users to choose one item from a list.
+
+View the [Rivet documentation for Select](https://rivet.uits.iu.edu/components/forms/select-input/).
+
+### Select Example
+
+Use the `note` property to provide contextual information to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Select
+  type="text"
+  name="text-demo"
+  label="Select Input"
+  note="This is a note."
+  margin={{ bottom: "md" }}
+>
+  <option value="">Choose an option...</option>
+  <option value="Option One">Option One</option>
+  <option value="Option Two">Option Two</option>
+  <option value="Option Three">Option Three</option>
+  <option value="Option Four">Option Four</option>
+</Select>
+```
+<!-- prettier-ignore-end -->
+
+### Inline Validation
+
+Use the `variant` property along with a `note` to provide validation feedback to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Select type="text"
+       name="select-valid-state"
+       variant="success"
+       label="Type"
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
+    <option value="">Choose an option...</option>
+    <option value="Steak">Steak</option>
+    <option value="Chops">Chops</option>
+    <option value="Ribs">Ribs</option>
+    <option value="Brisket">Brisket</option>
+</Select>
+
+<Select type="text"
+       name="select-warning-state"
+       variant="warning"
+       label="Type"
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
+    <option value="">Choose an option...</option>
+    <option value="Steak">Steak</option>
+    <option value="Chops">Chops</option>
+    <option value="Ribs">Ribs</option>
+    <option value="Brisket">Brisket</option>
+</Select>
+
+<Select type="text"
+       name="select-error-state"
+       variant="danger"
+       label="Type"
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
+    <option value="">Choose an option...</option>
+    <option value="Steak">Steak</option>
+    <option value="Chops">Chops</option>
+    <option value="Ribs">Ribs</option>
+    <option value="Brisket">Brisket</option>
+</Select>
+
+<Select type="text"
+       name="select-info-state"
+       variant="info"
+       label="Type"
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
+    <option value="">Choose an option...</option>
+    <option value="Steak">Steak</option>
+    <option value="Chops">Chops</option>
+    <option value="Ribs">Ribs</option>
+    <option value="Brisket">Brisket</option>
+</Select>
+```
+<!-- prettier-ignore-end -->

--- a/src/components/Input/Select.md
+++ b/src/components/Input/Select.md
@@ -13,6 +13,7 @@ Use the `note` property to provide contextual information to the user.
   name="text-demo"
   label="Select Input"
   note="This is a note."
+  margin={{ bottom: "md" }}
 >
   <option value="">Choose an option...</option>
   <option value="Option One">Option One</option>
@@ -33,7 +34,8 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-valid-state"
        variant="success"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -45,7 +47,8 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-warning-state"
        variant="warning"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -57,7 +60,8 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-error-state"
        variant="danger"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>
@@ -69,7 +73,8 @@ Use the `variant` property along with a `note` to provide validation feedback to
        name="select-info-state"
        variant="info"
        label="Type"
-       note={<> You must pick a <strong>Type</strong> of meat. </>}>
+       note={<> You must pick a <strong>Type</strong> of meat. </>}
+       margin={{bottom: 'md'}}>
     <option value="">Choose an option...</option>
     <option value="Steak">Steak</option>
     <option value="Chops">Chops</option>

--- a/src/components/Input/Select.test.jsx
+++ b/src/components/Input/Select.test.jsx
@@ -1,0 +1,133 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import Select from "./Select";
+
+describe("<Select />", () => {
+  describe("Rendering", () => {
+    it("should render without throwing an error", () => {
+      render(<Select label="Label" />);
+      expect(screen.getByRole("combobox", {})).toBeVisible();
+    });
+    it("should render the label", () => {
+      render(<Select label="Label" />);
+      expect(screen.getByText("Label", {})).toBeVisible();
+    });
+    it("should associate the label with the Select", () => {
+      render(<Select id="the_id" label="Label" />);
+      expect(screen.getByRole("combobox", {})).toHaveAttribute("id", "the_id");
+      expect(screen.getByText("Label", {})).toHaveProperty("htmlFor", "the_id");
+    });
+    it("should apply custom class", () => {
+      render(<Select className="my-class" label="Label" />);
+      expect(screen.getByRole("combobox", {}).closest("div")).toHaveClass(
+        "my-class"
+      );
+    });
+    it("should render its options", () => {
+      render(
+        <Select label="label">
+          <option>foo</option>
+          <option>bar</option>
+          <option>baz</option>
+        </Select>
+      );
+      expect(screen.getByRole("combobox", {}).children.length).toBe(3);
+    });
+    it("should apply sr-only class to label", () => {
+      render(<Select label="Label" labelVisibility="screen-reader-only" />);
+      expect(screen.getByText("Label", {})).toHaveClass("rvt-sr-only");
+    });
+  });
+  describe("Notes", () => {
+    it("should apply the note", () => {
+      render(<Select note="Note" label="Label" />);
+      expect(screen.getByText("Note", {})).toBeVisible();
+      expect(screen.getByText("Note", {})).toContainHTML("small");
+    });
+    it("should associate the input with the note", () => {
+      render(<Select id="the_id" note="Note" label="Label" />);
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-describedby",
+        "the_id_note"
+      );
+    });
+    it("should not apply the aria-describedby attribute when no note is present", () => {
+      render(<Select id="the_id" label="Label" />);
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-describedby",
+        ""
+      );
+    });
+  });
+  describe("Inline Alerts", () => {
+    it("info style", () => {
+      render(<Select variant="info" label="Label" note="🤔" />);
+      expect(screen.getByRole("combobox", {})).toHaveClass(
+        "rvt-validation-info"
+      );
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--info"
+      );
+    });
+    it("valid style", () => {
+      render(<Select variant="success" label="Label" note="😎" />);
+      expect(screen.getByRole("combobox", {})).toHaveClass(
+        "rvt-validation-success"
+      );
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--success"
+      );
+    });
+    it("warning style", () => {
+      render(<Select variant="warning" label="Label" note="🤨" />);
+      expect(screen.getByRole("combobox", {})).toHaveClass(
+        "rvt-validation-warning"
+      );
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--warning"
+      );
+    });
+    it("invalid style", () => {
+      render(<Select variant="danger" label="Label" note="😬" />);
+      expect(screen.getByRole("combobox", {})).toHaveClass(
+        "rvt-validation-danger"
+      );
+      expect(screen.getByRole("combobox", {})).toHaveAttribute(
+        "aria-invalid",
+        "true"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--danger"
+      );
+    });
+  });
+});

--- a/src/components/Input/Textarea.jsx
+++ b/src/components/Input/Textarea.jsx
@@ -1,0 +1,14 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import * as React from "react";
+import * as Rivet from "../util/Rivet";
+import { propTypes, renderInput } from "./common";
+
+const Textarea = renderInput("textarea");
+
+Textarea.displayName = "TextArea";
+Textarea.propTypes = propTypes;
+
+export default Rivet.rivetize(Textarea);

--- a/src/components/Input/Textarea.jsx
+++ b/src/components/Input/Textarea.jsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import * as Rivet from "../util/Rivet";
 import { propTypes, renderInput } from "./common";
 
-const Textarea = renderInput("textarea");
+const Textarea = (props) => <>{renderInput("textarea", props)}</>;
 
 Textarea.displayName = "TextArea";
 Textarea.propTypes = propTypes;

--- a/src/components/Input/Textarea.md
+++ b/src/components/Input/Textarea.md
@@ -4,7 +4,7 @@ Use the `note` property to provide contextual information to the user.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Textarea name="textarea-demo" label="Text Area" margin={{bottom: "md"}} />
+<Textarea name="textarea-demo" label="Text Area" />
 <Textarea name="textarea-demo-disabled" label="Text Area (Disabled)" disabled />
 ```
 <!-- prettier-ignore-end -->
@@ -18,25 +18,21 @@ Use the `variant` property along with a `note` to provide validation feedback to
 <Textarea name="textarea-valid"
           variant="success"
           label="Essay"
-          note={<>Your <strong>Essay</strong> is valid!</>}
-          margin={{bottom: "md"}} />
+          note={<>Your <strong>Essay</strong> is valid!</>} />
 
 <Textarea name="textarea-warning"
           variant="warning"
           label="Response"
-          note={<>Your <strong>Response</strong> has some misspellings!</>}
-          margin={{bottom: "md"}} />
+          note={<>Your <strong>Response</strong> has some misspellings!</>} />
 
 <Textarea name="textarea-invalid"
           variant="danger"
           label="Description"
-          note={<>Your <strong>Description</strong> has invalid characters.</>}
-          margin={{bottom: "md"}} />
+          note={<>Your <strong>Description</strong> has invalid characters.</>} />
 
 <Textarea name="textarea-info"
           variant="info"
           label="Message"
-          note={<>Add a <strong>Message</strong> to give users more information.</>}
-          margin={{bottom: "md"}} />
+          note={<>Add a <strong>Message</strong> to give users more information.</>} />
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Input/Textarea.md
+++ b/src/components/Input/Textarea.md
@@ -4,7 +4,7 @@ Use the `note` property to provide contextual information to the user.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Textarea name="textarea-demo" label="Text Area" />
+<Textarea name="textarea-demo" label="Text Area" margin={{bottom: "md"}} />
 <Textarea name="textarea-demo-disabled" label="Text Area (Disabled)" disabled />
 ```
 <!-- prettier-ignore-end -->
@@ -18,21 +18,25 @@ Use the `variant` property along with a `note` to provide validation feedback to
 <Textarea name="textarea-valid"
           variant="success"
           label="Essay"
-          note={<>Your <strong>Essay</strong> is valid!</>} />
+          note={<>Your <strong>Essay</strong> is valid!</>}
+          margin={{bottom: "md"}} />
 
 <Textarea name="textarea-warning"
           variant="warning"
           label="Response"
-          note={<>Your <strong>Response</strong> has some misspellings!</>} />
+          note={<>Your <strong>Response</strong> has some misspellings!</>}
+          margin={{bottom: "md"}} />
 
 <Textarea name="textarea-invalid"
           variant="danger"
           label="Description"
-          note={<>Your <strong>Description</strong> has invalid characters.</>} />
+          note={<>Your <strong>Description</strong> has invalid characters.</>}
+          margin={{bottom: "md"}} />
 
 <Textarea name="textarea-info"
           variant="info"
           label="Message"
-          note={<>Add a <strong>Message</strong> to give users more information.</>} />
+          note={<>Add a <strong>Message</strong> to give users more information.</>}
+          margin={{bottom: "md"}} />
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Input/Textarea.md
+++ b/src/components/Input/Textarea.md
@@ -1,0 +1,42 @@
+### Textarea Example
+
+Use the `note` property to provide contextual information to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Textarea name="textarea-demo" label="Text Area" margin={{bottom: "md"}} />
+<Textarea name="textarea-demo-disabled" label="Text Area (Disabled)" disabled />
+```
+<!-- prettier-ignore-end -->
+
+### Inline Validation
+
+Use the `variant` property along with a `note` to provide validation feedback to the user.
+
+<!-- prettier-ignore-start -->
+```jsx
+<Textarea name="textarea-valid"
+          variant="success"
+          label="Essay"
+          note={<>Your <strong>Essay</strong> is valid!</>}
+          margin={{bottom: "md"}} />
+
+<Textarea name="textarea-warning"
+          variant="warning"
+          label="Response"
+          note={<>Your <strong>Response</strong> has some misspellings!</>}
+          margin={{bottom: "md"}} />
+
+<Textarea name="textarea-invalid"
+          variant="danger"
+          label="Description"
+          note={<>Your <strong>Description</strong> has invalid characters.</>}
+          margin={{bottom: "md"}} />
+
+<Textarea name="textarea-info"
+          variant="info"
+          label="Message"
+          note={<>Add a <strong>Message</strong> to give users more information.</>}
+          margin={{bottom: "md"}} />
+```
+<!-- prettier-ignore-end -->

--- a/src/components/Input/Textarea.test.jsx
+++ b/src/components/Input/Textarea.test.jsx
@@ -1,0 +1,123 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import React from "react";
+import Textarea from "./Textarea";
+
+describe("<Texarea />", () => {
+  describe("Rendering", () => {
+    it("should render without throwing an error", () => {
+      render(<Textarea label="Label" />);
+      expect(screen.getByRole("textbox", {})).toBeVisible();
+    });
+    it("should render the label", () => {
+      render(<Textarea id="the_id" label="Label" />);
+      expect(screen.getByText("Label", {})).toBeVisible();
+    });
+    it("should associate the label with the input", () => {
+      render(<Textarea id="the_id" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute("id", "the_id");
+      expect(screen.getByText("Label", {})).toHaveProperty("htmlFor", "the_id");
+    });
+    it("should apply custom class", () => {
+      render(<Textarea className="my-class" label="Label" />);
+      expect(screen.getByRole("textbox", {}).closest("div")).toHaveClass(
+        "my-class"
+      );
+    });
+    it("should apply sr-only class to label", () => {
+      render(<Textarea label="Label" labelVisibility="screen-reader-only" />);
+      expect(screen.getByText("Label", {})).toHaveClass("rvt-sr-only");
+    });
+  });
+  describe("Notes", () => {
+    it("should apply the note", () => {
+      render(<Textarea note="Note" label="Label" />);
+      expect(screen.getByText("Note", {})).toBeVisible();
+      expect(screen.getByText("Note", {})).toContainHTML("small");
+    });
+    it("should associate the input with the note", () => {
+      render(<Textarea id="the_id" note="Note" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-describedby",
+        "the_id_note"
+      );
+    });
+    it("should not apply the aria-describedby attribute when no note is present", () => {
+      render(<Textarea id="the_id" label="Label" />);
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-describedby",
+        ""
+      );
+    });
+  });
+  describe("Inline Alerts", () => {
+    it("info style", () => {
+      render(<Textarea variant="info" label="Label" note="🤔" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-info"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤔", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--info"
+      );
+    });
+    it("valid style", () => {
+      render(<Textarea variant="success" label="Label" note="😎" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-success"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😎", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--success"
+      );
+    });
+    it("warning style", () => {
+      render(<Textarea variant="warning" label="Label" note="🤨" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-warning"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("🤨", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--warning"
+      );
+    });
+    it("invalid style", () => {
+      render(<Textarea variant="danger" label="Label" note="😬" />);
+      expect(screen.getByRole("textbox", {})).toHaveClass(
+        "rvt-validation-danger"
+      );
+      expect(screen.getByRole("textbox", {})).toHaveAttribute(
+        "aria-invalid",
+        "true"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert"
+      );
+      expect(screen.getByText("😬", {}).closest("div")).toHaveClass(
+        "rvt-inline-alert--danger"
+      );
+    });
+  });
+});

--- a/src/components/Input/common.jsx
+++ b/src/components/Input/common.jsx
@@ -1,0 +1,86 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+import * as React from "react";
+
+import InlineAlert from "../Alert/InlineAlert";
+import * as Rivet from "../util/Rivet";
+import classNames from "classnames";
+import * as PropTypes from "prop-types";
+
+const inputClassName = (elementName, variant) => {
+  const validationVariant = variant ? `rvt-validation-${variant}` : "";
+
+  switch (elementName) {
+    case "input":
+      return classNames("rvt-text-input", validationVariant);
+    default:
+      return classNames(`rvt-${elementName}`, validationVariant);
+  }
+};
+
+const noteFragment = (id, variant, note) =>
+  variant ? (
+    <InlineAlert id={id} variant={variant}>
+      {note}
+    </InlineAlert>
+  ) : (
+    <small id={id} className="rvt-display-block">
+      {note}
+    </small>
+  );
+
+export const propTypes = {
+  /** The label for the input */
+  label: PropTypes.string.isRequired,
+  /** Visibility modifier for the input's label */
+  labelVisibility: PropTypes.oneOf(["screen-reader-only"]),
+  /** An optional note that will be displayed below the input */
+  note: PropTypes.node,
+  /** Rivet style for inline validation */
+  variant: PropTypes.oneOf(["success", "danger", "info", "warning"]),
+};
+
+export const renderInput =
+  (elementName) =>
+  ({
+    id = Rivet.shortuid(),
+    label,
+    labelVisibility,
+    note,
+    variant,
+    className,
+    ...attrs
+  }) => {
+    const noteId = `${id}_note`;
+    const inputProps = {
+      id,
+      className: inputClassName(elementName, variant),
+      "aria-describedby": note ? noteId : "",
+      "aria-invalid": variant === "danger",
+      ...attrs,
+    };
+    return (
+      <div
+        className={classNames(
+          "rvt-container-sm",
+          "rvt-p-all-lg",
+          "rvt-p-all-xxl-lg-up",
+          className
+        )}
+      >
+        <label
+          htmlFor={id}
+          className={classNames(
+            "rvt-label",
+            Rivet.labelVisiblityClass(labelVisibility)
+          )}
+        >
+          {label}
+        </label>
+        {React.createElement(elementName, inputProps)}
+        {note && noteFragment(noteId, variant, note)}
+      </div>
+    );
+  };

--- a/src/components/Input/common.jsx
+++ b/src/components/Input/common.jsx
@@ -42,9 +42,9 @@ export const propTypes = {
   variant: PropTypes.oneOf(["success", "danger", "info", "warning"]),
 };
 
-export const renderInput =
-  (elementName) =>
-  ({
+export const renderInput = (
+  elementName,
+  {
     id = Rivet.shortuid(),
     label,
     labelVisibility,
@@ -52,35 +52,36 @@ export const renderInput =
     variant,
     className,
     ...attrs
-  }) => {
-    const noteId = `${id}_note`;
-    const inputProps = {
-      id,
-      className: inputClassName(elementName, variant),
-      "aria-describedby": note ? noteId : "",
-      "aria-invalid": variant === "danger",
-      ...attrs,
-    };
-    return (
-      <div
+  }
+) => {
+  const noteId = `${id}_note`;
+  const inputProps = {
+    id,
+    className: inputClassName(elementName, variant),
+    "aria-describedby": note ? noteId : "",
+    "aria-invalid": variant === "danger",
+    ...attrs,
+  };
+  return (
+    <div
+      className={classNames(
+        "rvt-container-sm",
+        "rvt-p-all-lg",
+        "rvt-p-all-xxl-lg-up",
+        className
+      )}
+    >
+      <label
+        htmlFor={id}
         className={classNames(
-          "rvt-container-sm",
-          "rvt-p-all-lg",
-          "rvt-p-all-xxl-lg-up",
-          className
+          "rvt-label",
+          Rivet.labelVisiblityClass(labelVisibility)
         )}
       >
-        <label
-          htmlFor={id}
-          className={classNames(
-            "rvt-label",
-            Rivet.labelVisiblityClass(labelVisibility)
-          )}
-        >
-          {label}
-        </label>
-        {React.createElement(elementName, inputProps)}
-        {note && noteFragment(noteId, variant, note)}
-      </div>
-    );
-  };
+        {label}
+      </label>
+      {React.createElement(elementName, inputProps)}
+      {note && noteFragment(noteId, variant, note)}
+    </div>
+  );
+};

--- a/src/components/Input/common.jsx
+++ b/src/components/Input/common.jsx
@@ -63,14 +63,7 @@ export const renderInput = (
     ...attrs,
   };
   return (
-    <div
-      className={classNames(
-        "rvt-container-sm",
-        "rvt-p-all-lg",
-        "rvt-p-all-xxl-lg-up",
-        className
-      )}
-    >
+    <div className={classNames(className)}>
       <label
         htmlFor={id}
         className={classNames(

--- a/src/components/Input/index.jsx
+++ b/src/components/Input/index.jsx
@@ -1,0 +1,7 @@
+/*
+Copyright (C) 2018 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
+export { default as Input } from "./Input";
+export { default as Textarea } from "./Textarea";
+export { default as Select } from "./Select";

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,3 +5,4 @@ SPDX-License-Identifier: BSD-3-Clause
 export * from "./Alert/index.jsx";
 export * from "./Button/index.jsx";
 export * from "./Dropdown/index.jsx";
+export * from "./Input/index.jsx";

--- a/src/components/util/Rivet.jsx
+++ b/src/components/util/Rivet.jsx
@@ -101,3 +101,10 @@ export const rivetize = (Component) => {
     );
   };
 };
+
+/**
+ * Determine whether to apply class limiting label visibility to screenreaders.
+ * @param visibility The desired visibility type.
+ */
+export const labelVisiblityClass = (visibility) =>
+  visibility === "screen-reader-only" ? "rvt-sr-only" : "";

--- a/styleguide.config.cjs
+++ b/styleguide.config.cjs
@@ -16,7 +16,10 @@ module.exports = {
   sections: [
     {
       name: "Forms",
-      components: "src/components/Button/[A-Z]*.jsx",
+      components: () => [
+        "src/components/Button/[A-Z]*.jsx",
+        "src/components/Input/[A-Z]*.jsx",
+      ],
     },
     {
       name: "Navigation",


### PR DESCRIPTION
1. The spacing and width of these components looks different then 1.0 because of changes to various classNames (example: rvt-container-sm rvt-p-all-xxl-lg-up rvt-m-bottom-md rvt-p-all-lg).
a. Examples before:
![Screenshot 2022-12-09 at 19 01 33](https://user-images.githubusercontent.com/11510046/206814122-8f694e2f-6f97-40a9-8f76-c401a66b0400.png)
![Screenshot 2022-12-09 at 19 03 28](https://user-images.githubusercontent.com/11510046/206814243-f165ee6c-aa2a-4629-bcf1-dc70a1524e6d.png)
![Screenshot 2022-12-09 at 19 02 11](https://user-images.githubusercontent.com/11510046/206814157-47e17c29-78fa-477f-a47f-b92140a435ab.png)
b. Examples after:
![Screenshot 2022-12-09 at 19 01 10](https://user-images.githubusercontent.com/11510046/206814095-2e6eb6c2-5f77-4dc4-b98c-93fd00b58563.png)
![Screenshot 2022-12-09 at 19 03 59](https://user-images.githubusercontent.com/11510046/206814287-700d79fb-7b1e-4fdc-83d6-2ff38520479d.png)
![Screenshot 2022-12-09 at 19 02 40](https://user-images.githubusercontent.com/11510046/206814187-f52bf5d7-6633-4c7c-8616-900e25b5581b.png)
3. In order to fix this warning (also for Select & Textarea):
`Warning: src/components/Input/Input.jsx matches a pattern defined in “components” or “sections” options in your style guide config but doesn’t export a component.`
I changed renderInput in common.jsx from a higher order function to a regular one and added an empty component (`<>{renderInput("input", props)}</>`). That gets rid of the warning at the expense of slightly wordy code

I am interested in feedback if anybody spots flaws / improvements on the above. Thanks!
