### PR TITLE
353 - Added wrapper for render fallback on error of rivetize comps

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -8,12 +8,7 @@ import PropTypes from "prop-types";
 
 import Icon, { IconNames } from "../util/RivetIcons";
 import * as Rivet from "../util/Rivet";
-import HeaderNavigationSecondary from "./HeaderNavigationSecondary";
-import HeaderNavigation from "./HeaderNavigation";
-import HeaderSearch from "./HeaderSearch";
-import HeaderMenu from "./HeaderMenu";
 import { TestUtils } from "../util/TestUtils";
-import HeaderAvatar from "./HeaderAvatar";
 
 const componentClass = "rvt-header-wrapper";
 
@@ -72,12 +67,6 @@ const Header = ({
     </header>
   );
 };
-
-Header.Navigation = HeaderNavigation;
-Header.Avatar = HeaderAvatar;
-Header.Menu = HeaderMenu;
-Header.Search = HeaderSearch;
-Header.NavigationSecondary = HeaderNavigationSecondary;
 
 Header.displayName = "Header";
 Header.propTypes = {

--- a/src/components/Header/Header.md
+++ b/src/components/Header/Header.md
@@ -1,6 +1,6 @@
 A header is a section at the top of each page that contains the title of your website or application and the IU trident logo. Headers can also contain navigation links and a search button.
 
-Branding guidelines require each site to have an IU-branded header.
+Branding guidelines require each site to have an IU-branded Header
 
 View the [Rivet documentation for Header](https://rivet.iu.edu/components/header/).
 
@@ -26,7 +26,7 @@ You can also override the default "/" URL for the link:
 ```
 <!-- prettier-ignore-end -->
 
-The width prop can be used to constrain the width of the header.
+The width prop can be used to constrain the width of the Header
 
 <!-- prettier-ignore-start -->
 
@@ -35,25 +35,25 @@ The width prop can be used to constrain the width of the header.
 ```
 <!-- prettier-ignore-end -->
 
-Header can also be provided the following components as props - [Header.Navigation](#/Navigation?id=headernavigation) which serves as the primary navigation for your site, [Header.Search](#/Navigation?id=headersearch) which provides a search functionality, and [Header.NavigationSecondary](#/Navigation?id=headernavigationsecondary) which serves as the secondary navigation.
+Header can also be provided the following components as props - [HeaderNavigation](#/Navigation?id=headernavigation) which serves as the primary navigation for your site, [HeaderSearch](#/Navigation?id=headersearch) which provides a search functionality, and [HeaderNavigationSecondary](#/Navigation?id=headernavigationsecondary) which serves as the secondary navigation.
 
 Header with Primary Navigation:
 
 <!-- prettier-ignore-start -->
 ```jsx
-const navigation = <Header.Navigation>
+const navigation = <HeaderNavigation>
   <ul>
     <li><a href={"#"}>Nav item one</a></li>
     <li data-rvt-c-header-nav-item__current><a href={"#"}>Nav item two</a></li>
     <li>
-      <Header.Menu label="Nav item three">
+      <HeaderMenu label="Nav item three">
         <a href={"#"}>Sub item one</a>
         <a href={"#"}>Sub item two</a>
         <a href={"#"}>Sub item three</a>
-      </Header.Menu>
+      </HeaderMenu>
     </li>
   </ul>
-</Header.Navigation>;
+</HeaderNavigation>;
 
 <Header title="Application Title" navigation={navigation} />
 ```
@@ -63,20 +63,20 @@ Header with Primary Navigation and Avatar:
 
 <!-- prettier-ignore-start -->
 ```jsx
-const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"}/>
-const navigation = <Header.Navigation avatar={avatar}>
+const avatar = <HeaderAvatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"}/>
+const navigation = <HeaderNavigation avatar={avatar}>
   <ul>
     <li><a href="#">Nav item one</a></li>
     <li><a href="#">Nav item two</a></li>
     <li data-rvt-c-header-nav-item__current>
-      <Header.Menu label="Nav item three">
+      <HeaderMenu label="Nav item three">
         <a href="#">Sub item one</a>
         <a href="#">Sub item two</a>
         <a href="#">Sub item three</a>
-      </Header.Menu>
+      </HeaderMenu>
     </li>
   </ul>
-</Header.Navigation>;
+</HeaderNavigation>;
 
 <Header title="Application Title" navigation={navigation}/>
 ```
@@ -86,7 +86,7 @@ Header with Search:
 
 <!-- prettier-ignore-start -->
 ```jsx
-const search = <Header.Search action={"/mySearchURL"} method={"post"}/>;
+const search = <HeaderSearch action={"/mySearchURL"} method={"post"}/>;
 <Header title="Application Title" search={search} />
 ```
 <!-- prettier-ignore-end -->
@@ -95,20 +95,20 @@ Header with Primary Navigation and Search:
 
 <!-- prettier-ignore-start -->
 ```jsx
-const navigation = <Header.Navigation>
+const navigation = <HeaderNavigation>
   <ul>
     <li><a href="#">Nav item one</a></li>
     <li><a href="#">Nav item two</a></li>
     <li data-rvt-c-header-nav-item__current>
-      <Header.Menu label="Nav item three">
+      <HeaderMenu label="Nav item three">
         <a href="#">Sub item one</a>
         <a href="#">Sub item two</a>
         <a href="#">Sub item three</a>
-      </Header.Menu>
+      </HeaderMenu>
     </li>
   </ul>
-</Header.Navigation>;
-const search = <Header.Search action={"/mySearchURL"} method={"post"}/>;
+</HeaderNavigation>;
+const search = <HeaderSearch action={"/mySearchURL"} method={"post"}/>;
 
 <Header title="Application Title" navigation={navigation} search={search} />
 ```
@@ -118,33 +118,33 @@ Header with Primary Navigation, Search, Avatar and Secondary Navigation:
 
 <!-- prettier-ignore-start -->
 ```jsx
-const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"}/>;
-const navigation = <Header.Navigation avatar={avatar}>
+const avatar = <HeaderAvatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"}/>;
+const navigation = <HeaderNavigation avatar={avatar}>
   <ul>
     <li><a href="#">Nav item one</a></li>
     <li><a href="#">Nav item two</a></li>
     <li data-rvt-c-header-nav-item__current>
-      <Header.Menu label="Nav item three">
+      <HeaderMenu label="Nav item three">
         <a href="#">Sub item one</a>
         <a href="#">Sub item two</a>
         <a href="#">Sub item three</a>
-      </Header.Menu>
+      </HeaderMenu>
     </li>
   </ul>
-</Header.Navigation>;
-const search = <Header.Search action={"/mySearchURL"} method={"post"}/>;
-const secondaryNavigation = <Header.NavigationSecondary title={"Component Library"}>
+</HeaderNavigation>;
+const search = <HeaderSearch action={"/mySearchURL"} method={"post"}/>;
+const secondaryNavigation = <HeaderNavigationSecondary title={"Component Library"}>
   <ul>
     <li><a href="#">Section item one</a></li>
     <li data-rvt-c-header-nav-item__current>
-      <Header.Menu label="Section item two">
+      <HeaderMenu label="Section item two">
         <a href="#">Sub tem one</a>
         <a href="#">Sub item two</a>
         <a href="#">Sub item three</a>
-      </Header.Menu>
+      </HeaderMenu>
     </li>
   </ul>
-</Header.NavigationSecondary>;
+</HeaderNavigationSecondary>;
 
 <Header title="Application Title" navigation={navigation} search={search} secondaryNavigation={secondaryNavigation}/>
 

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -3,6 +3,10 @@ import { prettyDOM, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 import Header from "./Header";
+import HeaderMenu from "./HeaderMenu";
+import HeaderNavigation from "./HeaderNavigation";
+import HeaderNavigationSecondary from "./HeaderNavigationSecondary";
+import HeaderSearch from "./HeaderSearch";
 import { TestUtils } from "../util/TestUtils";
 
 const testTitle = "Test title";
@@ -53,7 +57,7 @@ describe("<Header />", () => {
 
     it("should render all provided children", () => {
       const navigation = (
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
@@ -62,31 +66,31 @@ describe("<Header />", () => {
               <a href={"#"}>Nav item two</a>
             </li>
             <li>
-              <Header.Menu label="Nav item three">
+              <HeaderMenu label="Nav item three">
                 <a href={"#"}>Sub item one</a>
                 <a href={"#"}>Sub item two</a>
                 <a href={"#"}>Sub item three</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
-      const search = <Header.Search action={"/mySearchURL"} method={"post"} />;
+      const search = <HeaderSearch action={"/mySearchURL"} method={"post"} />;
       const secondaryNavigation = (
-        <Header.NavigationSecondary title={"Component Library"}>
+        <HeaderNavigationSecondary title={"Component Library"}>
           <ul>
             <li>
               <a href="#">Section item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Section item two">
+              <HeaderMenu label="Section item two">
                 <a href="#">Secondary nav sub item one</a>
                 <a href="#">Secondary nav sub item two</a>
                 <a href="#">Secondary nav sub item three</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.NavigationSecondary>
+        </HeaderNavigationSecondary>
       );
 
       render(

--- a/src/components/Header/HeaderAvatar.jsx
+++ b/src/components/Header/HeaderAvatar.jsx
@@ -38,7 +38,7 @@ const HeaderAvatar = ({ username, shortName, logoutURL }) => {
   );
 };
 
-HeaderAvatar.displayName = "Header.Avatar";
+HeaderAvatar.displayName = "HeaderAvatar";
 HeaderAvatar.propTypes = {
   /** The user's username */
   username: PropTypes.string.isRequired,

--- a/src/components/Header/HeaderAvatar.test.js
+++ b/src/components/Header/HeaderAvatar.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import Header from "./Header";
+import HeaderAvatar from "./HeaderAvatar";
 import { TestUtils } from "../util/TestUtils";
 
 describe("<HeaderAvatar/>", () => {
@@ -13,7 +13,7 @@ describe("<HeaderAvatar/>", () => {
     it("should render the provided username, short name, and logout link", () => {
       const link = "/logout";
       render(
-        <Header.Avatar
+        <HeaderAvatar
           username={username}
           shortName={shortName}
           logoutURL={link}
@@ -30,7 +30,7 @@ describe("<HeaderAvatar/>", () => {
     });
 
     it("does not show logout anchor if logoutURL is not provided", () => {
-      render(<Header.Avatar username={username} shortName={shortName} />);
+      render(<HeaderAvatar username={username} shortName={shortName} />);
 
       expect(screen.queryAllByRole("link")).toHaveLength(0);
     });

--- a/src/components/Header/HeaderMenu.jsx
+++ b/src/components/Header/HeaderMenu.jsx
@@ -186,7 +186,7 @@ const HeaderMenu = ({ children, label, href = "#", current, ...attrs }) => {
   );
 };
 
-HeaderMenu.displayName = "Header.Menu";
+HeaderMenu.displayName = "HeaderMenu";
 HeaderMenu.propTypes = {
   /** The label of the menu */
   label: PropTypes.string.isRequired,

--- a/src/components/Header/HeaderMenu.test.jsx
+++ b/src/components/Header/HeaderMenu.test.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import Header from "./Header";
+import HeaderMenu from "./HeaderMenu";
 
 import { TestUtils } from "../util/TestUtils";
 import userEvent from "@testing-library/user-event";
@@ -19,10 +19,10 @@ describe("<HeaderMenu/>", () => {
   describe("Rendering and styling", () => {
     it("should render all the provided children", () => {
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <a href="#">Sub item one</a>
           <a href={testHref}>Sub item two</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
       expect(screen.getByText("Sub item one")).toBeInTheDocument();
       expect(screen.getByText("Sub item two")).toBeInTheDocument();
@@ -30,10 +30,10 @@ describe("<HeaderMenu/>", () => {
 
     it("should retain any attributes provided to the children", () => {
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <a href="#">Sub item one</a>
           <a href={testHref}>Sub item two</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
       expect(screen.getByText("Sub item one")).toHaveAttribute("href", "#");
       expect(screen.getByText("Sub item two")).toHaveAttribute(
@@ -45,9 +45,9 @@ describe("<HeaderMenu/>", () => {
     it("should allow providing non-anchor elements as children", () => {
       const testId = "testButton";
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <button data-testid={testId}>test button</button>
-        </Header.Menu>
+        </HeaderMenu>
       );
       expect(
         screen.getByTestId(TestUtils.Header.menuContainerTestId)
@@ -57,9 +57,9 @@ describe("<HeaderMenu/>", () => {
     it("should provide the label and href props to the label anchor", () => {
       const testLabel = "Nav item";
       render(
-        <Header.Menu label={testLabel} href={testHref}>
+        <HeaderMenu label={testLabel} href={testHref}>
           <a href="#">Sub item</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
       expect(screen.getAllByRole("link")[0]).toHaveTextContent(testLabel);
       expect(screen.getAllByRole("link")[0]).toHaveAttribute("href", testHref);
@@ -67,9 +67,9 @@ describe("<HeaderMenu/>", () => {
 
     it("should hide the menu items by default", () => {
       render(
-        <Header.Menu label="Label">
+        <HeaderMenu label="Label">
           <a href="#">Sub item</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
       expect(
         screen.getByTestId(TestUtils.Header.menuItemsContainerTestId)
@@ -79,7 +79,7 @@ describe("<HeaderMenu/>", () => {
 
   describe("Defaulting props", () => {
     it("should default the label anchor's href prop to #, if not provided", () => {
-      render(<Header.Menu label="Nav item"></Header.Menu>);
+      render(<HeaderMenu label="Nav item"></HeaderMenu>);
       expect(screen.getAllByRole("link")[0]).toHaveAttribute("href", "#");
     });
   });
@@ -87,10 +87,10 @@ describe("<HeaderMenu/>", () => {
   describe("Toggle behavior", () => {
     beforeEach(() => {
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <a href="#">Sub item one</a>
           <a href="#">Sub item two</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
     });
 
@@ -213,10 +213,10 @@ describe("<HeaderMenu/>", () => {
   describe("Focus behavior", () => {
     beforeEach(() => {
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <a href="#">Sub item one</a>
           <a href="#">Sub item two</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
     });
 
@@ -306,9 +306,9 @@ describe("<HeaderMenu/>", () => {
   describe("Accessibility", () => {
     beforeEach(() => {
       render(
-        <Header.Menu label="Nav item three">
+        <HeaderMenu label="Nav item three">
           <a href="#">Sub item one</a>
-        </Header.Menu>
+        </HeaderMenu>
       );
     });
 

--- a/src/components/Header/HeaderNavigation.jsx
+++ b/src/components/Header/HeaderNavigation.jsx
@@ -92,7 +92,7 @@ const HeaderNavigation = ({ avatar, children, ...attrs }) => {
   );
 };
 
-HeaderNavigation.displayName = "Header.Navigation";
+HeaderNavigation.displayName = "HeaderNavigation";
 
 HeaderNavigation.propTypes = {
   /** The Avatar component */

--- a/src/components/Header/HeaderNavigation.test.jsx
+++ b/src/components/Header/HeaderNavigation.test.jsx
@@ -2,7 +2,9 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import Header from "./Header";
+import HeaderAvatar from "./HeaderAvatar";
+import HeaderMenu from "./HeaderMenu";
+import HeaderNavigation from "./HeaderNavigation";
 import { TestUtils } from "../util/TestUtils";
 import userEvent from "@testing-library/user-event";
 
@@ -19,14 +21,14 @@ describe("<HeaderNavigation />", () => {
 
     beforeEach(() => {
       const avatar = (
-        <Header.Avatar
+        <HeaderAvatar
           username={avatarUsername}
           shortName={avatarShortName}
           logoutURL={"/logout"}
         />
       );
       render(
-        <Header.Navigation avatar={avatar}>
+        <HeaderNavigation avatar={avatar}>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
@@ -35,14 +37,14 @@ describe("<HeaderNavigation />", () => {
               <a href={"#"}>Nav item two</a>
             </li>
             <li>
-              <Header.Menu label="Nav item three">
+              <HeaderMenu label="Nav item three">
                 <a href={"#"}>Sub item one</a>
                 <a href={"#"}>Sub item two</a>
                 <a href={"#"}>Sub item three</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
     });
 
@@ -73,13 +75,13 @@ describe("<HeaderNavigation />", () => {
   describe("Toggle behavior", () => {
     beforeEach(() => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
     });
 
@@ -187,13 +189,13 @@ describe("<HeaderNavigation />", () => {
   describe("Focus behavior", () => {
     beforeEach(() => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
     });
 
@@ -218,7 +220,7 @@ describe("<HeaderNavigation />", () => {
   describe("Accessibility", () => {
     it("should apply the aria-current attribute with value 'page' on an anchor nav item that is wrapped in an <li> with the data-rvt-c-header-nav-item__current attribute", () => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
@@ -227,7 +229,7 @@ describe("<HeaderNavigation />", () => {
               <a href={"#"}>Nav item two</a>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
       expect(screen.getByText("Nav item two")).toHaveAttribute(
         "aria-current",
@@ -237,18 +239,18 @@ describe("<HeaderNavigation />", () => {
 
     it("should apply the aria-current attribute with value 'page' on a HeaderMenu nav item that is wrapped in an <li> with the data-rvt-c-header-nav-item__current attribute", () => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Nav item two">
+              <HeaderMenu label="Nav item two">
                 <a href={"#"}>Sub item one</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
       expect(screen.getByText("Nav item two")).toHaveAttribute(
         "aria-current",
@@ -258,13 +260,13 @@ describe("<HeaderNavigation />", () => {
 
     it("should default the aria-expanded attribute to false", () => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
       expect(
         screen.getByTestId(TestUtils.Header.navButtonToggleTestId)
@@ -273,13 +275,13 @@ describe("<HeaderNavigation />", () => {
 
     it("should change the aria-expanded attribute to true when the nav is opened", async () => {
       render(
-        <Header.Navigation>
+        <HeaderNavigation>
           <ul>
             <li>
               <a href={"#"}>Nav item one</a>
             </li>
           </ul>
-        </Header.Navigation>
+        </HeaderNavigation>
       );
       await toggleNavThroughClick(); // open the nav
       expect(

--- a/src/components/Header/HeaderNavigationSecondary.jsx
+++ b/src/components/Header/HeaderNavigationSecondary.jsx
@@ -100,7 +100,7 @@ const HeaderNavigationSecondary = ({
   );
 };
 
-HeaderNavigationSecondary.displayName = "Header.NavigationSecondary";
+HeaderNavigationSecondary.displayName = "HeaderNavigationSecondary";
 HeaderNavigationSecondary.propTypes = {
   /** Optional prop to constrain the width of all content in the header */
   navWidth: PropTypes.oneOf([

--- a/src/components/Header/HeaderNavigationSecondary.test.jsx
+++ b/src/components/Header/HeaderNavigationSecondary.test.jsx
@@ -2,8 +2,8 @@ import React from "react";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import Header from "./Header";
-
+import HeaderMenu from "./HeaderMenu";
+import HeaderNavigationSecondary from "./HeaderNavigationSecondary";
 import { TestUtils } from "../util/TestUtils";
 import userEvent from "@testing-library/user-event";
 
@@ -23,7 +23,7 @@ describe("<HeaderNavigationSecondary/>", () => {
   describe("Rendering and styling", () => {
     beforeEach(() => {
       render(
-        <Header.NavigationSecondary
+        <HeaderNavigationSecondary
           title={testTitle}
           href={testHref}
           navWidth={"md"}
@@ -33,12 +33,12 @@ describe("<HeaderNavigationSecondary/>", () => {
               <a href="#">Section item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Section item two">
+              <HeaderMenu label="Section item two">
                 <a href="#">Sub item one</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.NavigationSecondary>
+        </HeaderNavigationSecondary>
       );
     });
 
@@ -63,18 +63,18 @@ describe("<HeaderNavigationSecondary/>", () => {
   describe("Defaulting props", () => {
     beforeEach(() => {
       render(
-        <Header.NavigationSecondary title={"Title"}>
+        <HeaderNavigationSecondary title={"Title"}>
           <ul>
             <li>
               <a href="#">Section item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Section item two">
+              <HeaderMenu label="Section item two">
                 <a href="#">Sub item one</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.NavigationSecondary>
+        </HeaderNavigationSecondary>
       );
     });
 
@@ -96,18 +96,18 @@ describe("<HeaderNavigationSecondary/>", () => {
   describe("Toggle behavior", () => {
     beforeEach(() => {
       render(
-        <Header.NavigationSecondary title={"Title"}>
+        <HeaderNavigationSecondary title={"Title"}>
           <ul>
             <li>
               <a href="#">Section item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Section item two">
+              <HeaderMenu label="Section item two">
                 <a href="#">Sub item one</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.NavigationSecondary>
+        </HeaderNavigationSecondary>
       );
     });
 
@@ -214,18 +214,18 @@ describe("<HeaderNavigationSecondary/>", () => {
   describe("Accessibility", () => {
     beforeEach(() => {
       render(
-        <Header.NavigationSecondary title={"Title"}>
+        <HeaderNavigationSecondary title={"Title"}>
           <ul>
             <li>
               <a href="#">Section item one</a>
             </li>
             <li data-rvt-c-header-nav-item__current>
-              <Header.Menu label="Section item two">
+              <HeaderMenu label="Section item two">
                 <a href="#">Sub item one</a>
-              </Header.Menu>
+              </HeaderMenu>
             </li>
           </ul>
-        </Header.NavigationSecondary>
+        </HeaderNavigationSecondary>
       );
     });
 

--- a/src/components/Header/HeaderSearch.jsx
+++ b/src/components/Header/HeaderSearch.jsx
@@ -103,7 +103,7 @@ const HeaderSearch = ({ action = "/search", method = "get", ...attrs }) => {
   );
 };
 
-HeaderSearch.displayName = "Header.Search";
+HeaderSearch.displayName = "HeaderSearch";
 HeaderSearch.propTypes = {
   /** The path that the form data is submitted to */
   action: PropTypes.string,

--- a/src/components/Header/HeaderSearch.test.jsx
+++ b/src/components/Header/HeaderSearch.test.jsx
@@ -2,8 +2,7 @@ import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
-import Header from "./Header";
-
+import HeaderSearch from "./HeaderSearch";
 import { TestUtils } from "../util/TestUtils";
 import userEvent from "@testing-library/user-event";
 
@@ -18,7 +17,7 @@ const toggleSearchThroughClick = async () => {
 describe("<HeaderSearch/>", () => {
   describe("Rendering and styling", () => {
     it("should render a toggle button, an input and a search button", async () => {
-      render(<Header.Search />);
+      render(<HeaderSearch />);
       expect(
         screen.getByTestId(TestUtils.Header.searchToggleButtonTestId)
       ).toBeInTheDocument();
@@ -33,7 +32,7 @@ describe("<HeaderSearch/>", () => {
     it("should apply to the form the provided values of the action and method props", async () => {
       const action = "action";
       const method = "post";
-      render(<Header.Search action={action} method={method} />);
+      render(<HeaderSearch action={action} method={method} />);
 
       expect(
         screen.getByTestId(TestUtils.Header.searchFormTestId)
@@ -46,7 +45,7 @@ describe("<HeaderSearch/>", () => {
 
   describe("Toggle behavior", () => {
     beforeEach(() => {
-      render(<Header.Search />);
+      render(<HeaderSearch />);
     });
 
     it("should show the search form when the toggle button is clicked", async () => {
@@ -137,7 +136,7 @@ describe("<HeaderSearch/>", () => {
 
   describe("Accessibility", () => {
     beforeEach(() => {
-      render(<Header.Search />);
+      render(<HeaderSearch />);
     });
 
     it("should default the aria-expanded attribute to false", () => {

--- a/src/components/Header/childUtils.jsx
+++ b/src/components/Header/childUtils.jsx
@@ -10,7 +10,7 @@ const renderHeaderNavListItem = (child) => {
 
   let childrenWithProps = React.Children.map(child.props.children, (child) => {
     const childType = child && child["type"];
-    const isHeaderMenu = getDisplayName(childType) === HeaderMenu.displayName;
+    const isHeaderMenu = getDisplayName(childType) === "rivetizedComponent";
     const isAnchor = childType === "a";
 
     const headerMenuProps = { ...(isListItemCurrent && { current: true }) };

--- a/src/components/util/ErrorBoundary.jsx
+++ b/src/components/util/ErrorBoundary.jsx
@@ -1,0 +1,29 @@
+import React from "react";
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    console.log("Error set");
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.log(error);
+  }
+
+  render() {
+    const { children, errorFallback = <div>Error Rendering Element</div> } =
+      this.props;
+    const { hasError } = this.state;
+    if (hasError) {
+      return errorFallback;
+    }
+
+    return children;
+  }
+}

--- a/src/components/util/Rivet.jsx
+++ b/src/components/util/Rivet.jsx
@@ -33,6 +33,7 @@ import {
   parseRivetSingleListUtility,
   parseRivetSpacing,
 } from "./RivetizeAux.js";
+import ErrorBoundary from "./ErrorBoundary.jsx";
 
 /**
  *  Helper and Styling Functions
@@ -45,102 +46,108 @@ export const shortuid = () => {
 };
 
 export const rivetize = (Component) => {
-  let rivetizedComponent = ({
-    alignContent,
-    alignItems,
-    alignSelf,
-    bg,
-    border,
-    borderColor,
-    className,
-    color,
-    display,
-    flex,
-    flexDirection,
-    flexWrap,
-    flow,
-    fontFamily,
-    grow,
-    hide,
-    justifyContent,
-    lhTitle,
-    margin,
-    padding,
-    prose,
-    shadow,
-    shrink,
-    stopBreak,
-    textAlign,
-    typescale,
-    uppercase,
-    weight,
-    width,
-    z,
-    ...attrs
-  }) => {
+  let rivetizedComponent = (props) => {
+    const {
+      alignContent,
+      alignItems,
+      alignSelf,
+      bg,
+      border,
+      borderColor,
+      className,
+      color,
+      display,
+      errorFallback,
+      flex,
+      flexDirection,
+      flexWrap,
+      flow,
+      fontFamily,
+      grow,
+      hide,
+      justifyContent,
+      lhTitle,
+      margin,
+      padding,
+      prose,
+      shadow,
+      shrink,
+      stopBreak,
+      textAlign,
+      typescale,
+      uppercase,
+      weight,
+      width,
+      z,
+    } = props;
     return (
-      <Component
-        className={classNames(
-          parseRivetMultiListUtility(alignContent, AlignContent, `rvt-content`),
-          parseRivetMultiListUtility(alignItems, AlignItems, `rvt-items`),
-          parseRivetMultiListUtility(alignSelf, AlignSelf, `rvt`),
-          parseRivetSingleListUtility(bg, Color, `rvt-bg-${bg}`),
-          parseRivetBorder(border),
-          parseRivetSingleListUtility(
-            borderColor,
-            BorderColor,
-            `rvt-border-color-${borderColor}`
-          ),
-          parseRivetSingleListUtility(color, Color, `rvt-color-${color}`),
-          parseRivetSingleListUtility(
-            display,
-            Display,
-            `rvt-display-${display}`
-          ),
-          parseRivetFlex(flex),
-          parseRivetMultiListUtility(flexDirection, FlexDirection, `rvt-flex`),
-          parseRivetMultiListUtility(flexWrap, FlexWrap, `rvt`),
-          parseRivetBooleanUtility(flow, "rvt-flow"),
-          parseRivetMultiListUtility(grow, FlexShrinkGrow, `rvt-grow`),
-          parseRivetSingleListUtility(
-            fontFamily,
-            FontFamily,
-            `rvt-font-${fontFamily}`
-          ),
-          parseRivetHidden(hide),
-          parseRivetMultiListUtility(
-            justifyContent,
-            JustifyContent,
-            `rvt-justify`
-          ),
-          parseRivetBooleanUtility(lhTitle, "rvt-lh-title"),
-          parseRivetSpacing("m", margin),
-          parseRivetSpacing("p", padding),
-          parseRivetBooleanUtility(prose, "rvt-prose"),
-          parseRivetShadow(shadow),
-          parseRivetMultiListUtility(shrink, FlexShrinkGrow, `rvt-shrink`),
-          parseRivetBooleanUtility(stopBreak, "rvt-text-nobr"),
-          parseRivetSingleListUtility(
-            textAlign,
-            TextAlign,
-            `rvt-text-${textAlign}`
-          ),
-          parseRivetMultiListUtility(typescale, Typescale, `rvt-ts`),
-          parseRivetBooleanUtility(uppercase, "rvt-text-uppercase"),
-          parseRivetSingleListUtility(weight, Weight, `rvt-text-${weight}`),
-          parseRivetMultiListUtility(width, Width, `rvt-width`),
-          parseRivetSingleListUtility(z, ZIndex, `rvt-z-${z * 100}`),
-          className
-        )}
-        {...attrs}
-      />
+      <ErrorBoundary errorFallback={errorFallback}>
+        <Component
+          className={classNames(
+            parseRivetMultiListUtility(
+              alignContent,
+              AlignContent,
+              `rvt-content`
+            ),
+            parseRivetMultiListUtility(alignItems, AlignItems, `rvt-items`),
+            parseRivetMultiListUtility(alignSelf, AlignSelf, `rvt`),
+            parseRivetSingleListUtility(bg, Color, `rvt-bg-${bg}`),
+            parseRivetBorder(border),
+            parseRivetSingleListUtility(
+              borderColor,
+              BorderColor,
+              `rvt-border-color-${borderColor}`
+            ),
+            parseRivetSingleListUtility(color, Color, `rvt-color-${color}`),
+            parseRivetSingleListUtility(
+              display,
+              Display,
+              `rvt-display-${display}`
+            ),
+            parseRivetFlex(flex),
+            parseRivetMultiListUtility(
+              flexDirection,
+              FlexDirection,
+              `rvt-flex`
+            ),
+            parseRivetMultiListUtility(flexWrap, FlexWrap, `rvt`),
+            parseRivetBooleanUtility(flow, "rvt-flow"),
+            parseRivetMultiListUtility(grow, FlexShrinkGrow, `rvt-grow`),
+            parseRivetSingleListUtility(
+              fontFamily,
+              FontFamily,
+              `rvt-font-${fontFamily}`
+            ),
+            parseRivetHidden(hide),
+            parseRivetMultiListUtility(
+              justifyContent,
+              JustifyContent,
+              `rvt-justify`
+            ),
+            parseRivetBooleanUtility(lhTitle, "rvt-lh-title"),
+            parseRivetSpacing("m", margin),
+            parseRivetSpacing("p", padding),
+            parseRivetBooleanUtility(prose, "rvt-prose"),
+            parseRivetShadow(shadow),
+            parseRivetMultiListUtility(shrink, FlexShrinkGrow, `rvt-shrink`),
+            parseRivetBooleanUtility(stopBreak, "rvt-text-nobr"),
+            parseRivetSingleListUtility(
+              textAlign,
+              TextAlign,
+              `rvt-text-${textAlign}`
+            ),
+            parseRivetMultiListUtility(typescale, Typescale, `rvt-ts`),
+            parseRivetBooleanUtility(uppercase, "rvt-text-uppercase"),
+            parseRivetSingleListUtility(weight, Weight, `rvt-text-${weight}`),
+            parseRivetMultiListUtility(width, Width, `rvt-width`),
+            parseRivetSingleListUtility(z, ZIndex, `rvt-z-${z * 100}`),
+            className
+          )}
+          {...props}
+        />
+      </ErrorBoundary>
     );
   };
-
-  // copy any properties set on the original component. Needed for child components (like Header.Navigation), which would otherwise be lost.
-  for (const [key, val] of Object.entries(Component)) {
-    rivetizedComponent[key] = val;
-  }
 
   return rivetizedComponent;
 };

--- a/src/components/util/RivetIcons.jsx
+++ b/src/components/util/RivetIcons.jsx
@@ -27,7 +27,7 @@ export const IconNames = {
   TOGGLE_CLOSE: "toggle-close",
   TOGGLE_SEARCH: "toggle-search",
   TWITTER: "twitter",
-  YOUTUBE: "youtube"
+  YOUTUBE: "youtube",
 };
 
 const IconCore = ({ children, ...attrs }) => (
@@ -166,7 +166,11 @@ const icoToggleOpen = (attrs) => (
 );
 
 const icoToggleSearch = (attrs) => (
-  <IconCore {...attrs} className="rvt-global-toggle__search" fill="currentColor">
+  <IconCore
+    {...attrs}
+    className="rvt-global-toggle__search"
+    fill="currentColor"
+  >
     <path
       d="M15.71,14.29,10.89,9.47a6,6,0,1,0-1.42,1.42l4.82,4.82a1,1,0,0,0,1.42,0A1,1,0,0,0,15.71,14.29ZM6,10a4,4,0,1,1,4-4A4,4,0,0,1,6,10Z"
       fill="currentColor"
@@ -207,7 +211,7 @@ Icon.displayName = "Icon";
 Icon.defaultProps = DefaultIconProps;
 Icon.propTypes = {
   name: PropTypes.oneOf([
-		IconNames.CARET_DOWN,
+    IconNames.CARET_DOWN,
     IconNames.FACEBOOK,
     IconNames.FILE,
     IconNames.INSTAGRAM,
@@ -218,7 +222,7 @@ Icon.propTypes = {
     IconNames.TRIDENT_HEADER,
     IconNames.TOGGLE_SEARCH,
     IconNames.TWITTER,
-    IconNames.YOUTUBE
+    IconNames.YOUTUBE,
   ]),
 };
 


### PR DESCRIPTION
Work to add Error Boundary for rivetize components.  The prop type validations however do not trigger the react library to call `getDerivedStateFromError` so while it would work for errors which trigger a JavaScript failure (like NPE) it does not work for component prop violations (missing required prop, invalid type).  

PR opened for review purposes until direction is decided regarding this issue.