### PR TITLE
ci: reenable code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
       - store_test_results:
           path: ./junit.xml
       - codecov/upload:
-          file: ./junit.xml
+          file: ./coverage/cobertura-coverage.xml
 
 # Job orchestration
 workflows:

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,6 @@
 module.exports = {
   testEnvironment: "jsdom",
+  collectCoverage: true,
+  reporters: ["default", "jest-junit"],
+  coverageReporters: ["text", "cobertura"],
 };


### PR DESCRIPTION
Code coverage was not being collected and uploaded correctly. This change should prompt the codecov bot to comment on this PR indicating code coverage is working again.