### PR TITLE
docs: fix privacylink typo in BaseFooter component

### DIFF
--- a/src/components/Footer/BaseFooter.jsx
+++ b/src/components/Footer/BaseFooter.jsx
@@ -8,7 +8,7 @@ import * as PropTypes from "prop-types";
 
 import Icon from "../util/RivetIcons";
 import * as Rivet from "../util/Rivet";
-import { parseRivetMultiListUtility }from "../util/RivetizeAux";
+import { parseRivetMultiListUtility } from "../util/RivetizeAux";
 
 /**
  * Use the Base Footer component at the bottom of all pages
@@ -28,7 +28,7 @@ const BaseFooter = ({
     variant ? `rvt-footer-base--${variant}` : "",
     className
   );
-  const year = !copyrightYear ? (new Date()).getFullYear() : copyrightYear
+  const year = !copyrightYear ? new Date().getFullYear() : copyrightYear;
   return (
     <footer className={classes} {...attrs}>
       <div className={parseRivetMultiListUtility(size, SIZES, "rvt-container")}>
@@ -36,24 +36,25 @@ const BaseFooter = ({
           <div className="rvt-footer-base__logo">
             <Icon height="24" name="logo" viewBox="0 0 24 24" width="24" />
           </div>
-          <ul className={`rvt-footer-base__list ${"full" === size ? "rvt-m-lr-sm" : ''}`}>
+          <ul
+            className={`rvt-footer-base__list ${
+              "full" === size ? "rvt-m-lr-sm" : ""
+            }`}
+          >
             <BaseFooterLink
               openInNewWindow={openInNewWindow}
               url="https://accessibility.iu.edu/assistance/"
             >
               Accessibility
             </BaseFooterLink>
-            <BaseFooterLink
-              openInNewWindow={openInNewWindow}
-              url={privacyUrl}
-            >
+            <BaseFooterLink openInNewWindow={openInNewWindow} url={privacyUrl}>
               Privacy Notice
             </BaseFooterLink>
             <li className="rvt-footer-base__item">
               <a
                 className="rvt-footer-base__link"
                 href="https://www.iu.edu/copyright/index.html"
-                {...(openInNewWindow && {target: "_blank" })}
+                {...(openInNewWindow && { target: "_blank" })}
               >
                 Copyright
               </a>{" "}
@@ -61,7 +62,7 @@ const BaseFooter = ({
               <a
                 className="rvt-footer-base__link"
                 href="https://www.iu.edu"
-                {...(openInNewWindow && {target: "_blank" })}
+                {...(openInNewWindow && { target: "_blank" })}
               >
                 Indiana University
               </a>
@@ -82,7 +83,7 @@ const BaseFooterLink = ({ children, openInNewWindow, url }) => {
       <a
         className="rvt-footer-base__link"
         href={url}
-        {...(openInNewWindow && {target: "_blank" })}
+        {...(openInNewWindow && { target: "_blank" })}
       >
         {children}
       </a>
@@ -90,16 +91,16 @@ const BaseFooterLink = ({ children, openInNewWindow, url }) => {
   );
 };
 
-const SIZES = ["sm", "md", "lg", "xl"]
+const SIZES = ["sm", "md", "lg", "xl"];
 
 BaseFooter.displayName = "BaseFooter";
 BaseFooter.propTypes = {
   /** The year of the page copyright */
   copyrightYear: PropTypes.string,
-  /** The url for privay link, if no provided url link will not display*/
+  /** The url for privacy link, if no provided url link will not display*/
   privacyUrl: PropTypes.string,
   /** The container size for content */
-  size:PropTypes.oneOf([...SIZES, "full"]),
+  size: PropTypes.oneOf([...SIZES, "full"]),
   /** The variant type which determines how the footer is styled */
   variant: PropTypes.oneOf(["light"]),
 };


### PR DESCRIPTION
Fix a typo in the documentation for the BaseFooter privacyLink property.