### PR TITLE
fix: Rendered provided id for dismissed alerts (#439)

### DIFF
--- a/src/components/Alert/Alert.jsx
+++ b/src/components/Alert/Alert.jsx
@@ -7,6 +7,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 
 import * as Rivet from "../util/Rivet";
+import { TestUtils } from "../util/TestUtils.js";
 
 /**
  * Use the alert component to show brief important messages to the user like errors, action confirmations, or system status.
@@ -19,6 +20,7 @@ const Alert = ({
   id = Rivet.shortuid(),
   className,
   children,
+  testMode = false,
   ...attrs
 }) => {
   const alertId = id;
@@ -36,6 +38,7 @@ const Alert = ({
         className="rvt-alert__dismiss"
         data-rvt-alert-close
         onClick={onDismiss}
+        {...(testMode && { "data-testid": TestUtils.Alert.dismiss })}
       >
         <span className="rvt-sr-only">Dismiss this alert</span>
         <svg
@@ -64,6 +67,7 @@ const Alert = ({
       role="alert"
       aria-labelledby={titleId}
       data-rvt-alert={variant}
+      {...(testMode && { "data-testid": TestUtils.Alert.container })}
       {...ariaProps}
       {...attrs}
     >
@@ -82,6 +86,8 @@ Alert.propTypes = {
   isOpen: PropTypes.bool,
   /** A function that can be called to have side-effects when the alert dismissal button is selected */
   onDismiss: PropTypes.func,
+  /** [Developer] Adds data-testId attributes for component testing */
+  testMode: PropTypes.bool,
   /** An extremely brief title for the alert */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   /** The variant type which determines how the alert is styled */

--- a/src/components/Alert/Alert.test.jsx
+++ b/src/components/Alert/Alert.test.jsx
@@ -8,6 +8,9 @@ import user from "@testing-library/user-event";
 import React from "react";
 
 import Alert from "./Alert";
+import { TestUtils } from "../util/TestUtils.js";
+
+const testIds = TestUtils.Alert;
 
 describe("<Alert />", () => {
   const titleText = "A Test Component";
@@ -114,6 +117,13 @@ describe("<Alert />", () => {
       await user.click(screen.getByRole("button"));
 
       expect(screen.getByRole("alert")).toBeVisible();
+    });
+  });
+  describe("Options", () => {
+    it("default is test mode off", () => {
+      render(<Alert title={titleText} variant="info" />);
+      const element = screen.queryByTestId(testIds.container);
+      expect(element).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/Alert/DismissibleAlert.jsx
+++ b/src/components/Alert/DismissibleAlert.jsx
@@ -9,13 +9,7 @@ import * as Rivet from "../util/Rivet";
 import Alert from "./Alert";
 
 /** The `DismissibleAlert` allows the user to remove the alert from view. This component provides a close button and implements visibility state management for a standard `Alert`. */
-const DismissibleAlert = ({
-  id = Rivet.shortuid(),
-  onDismiss = () => {},
-  title,
-  variant,
-  ...other
-}) => {
+const DismissibleAlert = ({ onDismiss = () => {}, ...other }) => {
   const [isOpen, setOpen] = useState(true);
 
   const handleDismiss = () => {
@@ -23,15 +17,7 @@ const DismissibleAlert = ({
     onDismiss && onDismiss();
   };
 
-  return (
-    <Alert
-      title={title}
-      variant={variant}
-      onDismiss={handleDismiss}
-      isOpen={isOpen}
-      {...other}
-    />
-  );
+  return <Alert onDismiss={handleDismiss} isOpen={isOpen} {...other} />;
 };
 
 DismissibleAlert.displayName = "DismissableAlert";
@@ -40,6 +26,8 @@ DismissibleAlert.propTypes = {
   id: PropTypes.string,
   /** A function that can be called to have side-effects when the alert is dismissed */
   onDismiss: PropTypes.func,
+  /** [Developer] Adds data-testId attributes for component testing */
+  testMode: PropTypes.bool,
   /** An extremely brief title for the alert */
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
   /** The variant type which determines how the alert is styled */

--- a/src/components/Alert/DismissibleAlert.test.jsx
+++ b/src/components/Alert/DismissibleAlert.test.jsx
@@ -8,18 +8,20 @@ import user from "@testing-library/user-event";
 import React from "react";
 
 import DismissableAlert from "./DismissibleAlert";
+import { TestUtils } from "../util/TestUtils.js";
+
+const testIds = TestUtils.Alert;
 
 describe("<DismissableAlert />", () => {
   const titleText = "A Test Component";
-
+  const testDismissBehavior = jest.fn();
   describe("Dismiss behavior", () => {
     it("should include dismiss button", () => {
-      const customDismissBehavior = jest.fn();
       render(
         <DismissableAlert
           title={titleText}
           variant="info"
-          onDismiss={customDismissBehavior}
+          onDismiss={testDismissBehavior}
         />
       );
       expect(screen.getByRole("button")).toBeVisible();
@@ -50,6 +52,42 @@ describe("<DismissableAlert />", () => {
       await user.click(screen.getByRole("button"));
 
       expect(screen.queryByRole("alert")).toBeNull;
+    });
+  });
+  describe("Options", () => {
+    it("if an Id is set it is rendered on alert", () => {
+      const testId = "alert-test";
+      render(
+        <DismissableAlert
+          id={testId}
+          onDismiss={testDismissBehavior}
+          testMode
+          title={titleText}
+          variant="info"
+        />
+      );
+      const element = screen.queryByTestId(testIds.container);
+      expect(element).toHaveAttribute("id", testId);
+    });
+    it("if no on dismiss event is given, alert closes on dismiss", async () => {
+      render(<DismissableAlert testMode title={titleText} variant="info" />);
+      const element = screen.queryByTestId(testIds.container);
+      expect(element).toBeVisible();
+      const dismissElement = screen.queryByTestId(testIds.dismiss);
+      await user.click(dismissElement);
+
+      expect(element).not.toBeVisible();
+    });
+    it("default is test mode off", () => {
+      render(
+        <DismissableAlert
+          onDismiss={testDismissBehavior}
+          title={titleText}
+          variant="info"
+        />
+      );
+      const element = screen.queryByTestId(testIds.container);
+      expect(element).not.toBeInTheDocument();
     });
   });
 });

--- a/src/components/util/TestUtils.js
+++ b/src/components/util/TestUtils.js
@@ -6,10 +6,14 @@ export const TestUtils = {
   Accordion: {
     container: "accordion-container",
     header: "accordion-header",
-    panel: "accordion-panel"
+    panel: "accordion-panel",
+  },
+  Alert: {
+    container: "Alert-container",
+    dismiss: "Alert-dismiss",
   },
   CallToAction: {
-    link: "cta-link"
+    link: "cta-link",
   },
   ButtonGroup: { testId: "buttonGroup_testId" },
   SegmentedButton: { testId: "segmentedButton_testId" },
@@ -43,7 +47,7 @@ export const TestUtils = {
     avatarUsernameTestId: "avatar-username__testid",
     headerWidthDivTestId: "header-width__testid",
     headerMenuItemContainer: "header-menuitem__container",
-    headerMenuItemAnchor: "header-menuitem__anchor"
+    headerMenuItemAnchor: "header-menuitem__anchor",
   },
   Hero: {
     container: "hero-container",
@@ -65,13 +69,13 @@ export const TestUtils = {
     container: "billboard-container",
     content: "billboard-content",
     image: "billboard-image",
-    title: "billboard-title"
+    title: "billboard-title",
   },
   CalendarTile: {
     container: "calendartile-container",
     day: "calendartile-day",
     month: "calendartile-month",
-    year: "calendartile-year"
+    year: "calendartile-year",
   },
   Card: {
     container: "card-container",
@@ -79,24 +83,24 @@ export const TestUtils = {
     eyebrow: "card-eyebrow",
     image: "card-image",
     meta: "card-meta",
-    title: "card-title"
+    title: "card-title",
   },
   Quote: {
     container: "quote-container",
     content: "quote-content",
     avatar: "quote-avatar",
-    citation: "quote-citation"
+    citation: "quote-citation",
   },
   Stat: {
     container: "stat-container",
     description: "stat-description",
     group: "stat-group",
     image: "stat-image",
-    number: "stat-number"
+    number: "stat-number",
   },
   StepIndicator: {
     container: "stepIndicator-container",
-    step: "stepIndicator-step"
+    step: "stepIndicator-step",
   },
   Timeline: { testId: "timeline__testId" },
   SeriesNav: {
@@ -104,7 +108,7 @@ export const TestUtils = {
     controlLabel: "seriesNav-label",
     controlText: "seriesNav-text",
     previous: "seriesNav-previous",
-    next: "seriesNav-next"
+    next: "seriesNav-next",
   },
   Sidenav: {
     container: "sidenav-container",
@@ -112,12 +116,12 @@ export const TestUtils = {
     menu: "sidenav-menu",
     menuButton: "sidenav-menu-button",
     menuContent: "sidenav-menu-content",
-    menuLabel: "sidenav-menu-label"
+    menuLabel: "sidenav-menu-label",
   },
   Subnav: {
     container: "subnav-container",
     itemContainer: "subnav-item",
-    itemLink: "subnav-item-link"
+    itemLink: "subnav-item-link",
   },
   Switch: {
     container: "switch-container",
@@ -125,12 +129,12 @@ export const TestUtils = {
   Tabs: {
     container: "tabs-container",
     controls: "tabs-controls",
-    panel: "tabs-panel"
+    panel: "tabs-panel",
   },
 
   LinkHub: {
     container: "linkhub-container",
     itemContainer: "linkhub-description",
-    itemLink: "linkhub-group"
-  }
+    itemLink: "linkhub-group",
+  },
 };


### PR DESCRIPTION
Currently when using the DismissableAlert component a generated Id is always used during render even if developers supply an id property to the component.  This is because id is one of the properties declared and deconstructed from the passed in props but it is not then passed through to the Alert component used for render so the Alert generates an id.  This PR removes several declared properties in the DismissableAlert component that are not directly used there so that they are passed through with the rest of the "other" properties to the Alert component.