### PR TITLE
feat: support fluid header width

### DIFF
--- a/src/components/Header/BaseHeader.jsx
+++ b/src/components/Header/BaseHeader.jsx
@@ -15,12 +15,14 @@ const BaseHeader = ({
   className,
   title,
   subtitle,
-  headerWidth = "xl",
+  headerWidth = "fluid",
   homeUrl,
   secondaryNavigation,
   testMode = false,
   ...attrs
 }) => {
+  const widthClass =
+    headerWidth === "fluid" ? "rvt-p-lr-md" : "rvt-container-" + headerWidth;
   const titleBlock = (
     <>
       <div className="rvt-lockup__tab">
@@ -31,7 +33,7 @@ const BaseHeader = ({
         <span className="rvt-lockup__subtitle">{subtitle}</span>
       </div>
     </>
-  )
+  );
   return (
     <header {...attrs} className={classNames("rvt-header-wrapper", className)}>
       <a
@@ -43,35 +45,37 @@ const BaseHeader = ({
       </a>
       <div className="rvt-header-global">
         <div
-          className={"rvt-container-" + headerWidth}
-          {...(testMode && { "data-testid": TestUtils.Header.headerWidthDivTestId })}
+          className={widthClass}
+          {...(testMode && {
+            "data-testid": TestUtils.Header.headerWidthDivTestId,
+          })}
         >
           <div className="rvt-header-global__inner">
             <div className="rvt-header-global__logo-slot">
-              {
-                homeUrl &&
-                  <a
-                    className="rvt-lockup"
-                    href={homeUrl}
-                    {...(testMode && { "data-testid": TestUtils.Header.anchorTestId })}
-                  >
-                    {titleBlock}
-                  </a>
-              }
-              {
-                !homeUrl &&
-                  <div
-                    className="rvt-lockup"
-                    {...(testMode && { "data-testid": TestUtils.Header.anchorTestId })}
-                  >
-                    {titleBlock}
-                  </div>
-                }
+              {homeUrl && (
+                <a
+                  className="rvt-lockup"
+                  href={homeUrl}
+                  {...(testMode && {
+                    "data-testid": TestUtils.Header.anchorTestId,
+                  })}
+                >
+                  {titleBlock}
+                </a>
+              )}
+              {!homeUrl && (
+                <div
+                  className="rvt-lockup"
+                  {...(testMode && {
+                    "data-testid": TestUtils.Header.anchorTestId,
+                  })}
+                >
+                  {titleBlock}
+                </div>
+              )}
             </div>
             {children && (
-              <div className="rvt-header-global__controls">
-                {children}
-              </div>
+              <div className="rvt-header-global__controls">{children}</div>
             )}
           </div>
         </div>
@@ -80,7 +84,6 @@ const BaseHeader = ({
     </header>
   );
 };
-
 
 BaseHeader.displayName = "BaseHeader";
 BaseHeader.propTypes = {
@@ -101,11 +104,12 @@ BaseHeader.propTypes = {
     "xxl",
     "3-xl",
     "4-xl",
+    "fluid",
   ]),
   /** The secondary navigation component */
   secondaryNavigation: PropTypes.element,
   /** [Developer] Adds data-testId attributes for component testing */
-  testMode: PropTypes.bool
+  testMode: PropTypes.bool,
 };
 
 export default Rivet.rivetize(BaseHeader);

--- a/src/components/Header/BaseHeader.test.jsx
+++ b/src/components/Header/BaseHeader.test.jsx
@@ -52,11 +52,22 @@ describe("<BaseHeader />", () => {
       );
     });
 
-    it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
-      render(<BaseHeader testMode title={testTitle} headerWidth={testWidth} />);
-      expect(
-        screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
-      ).toHaveClass("rvt-container-" + testWidth);
+    describe("Header Width", () => {
+      it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
+        render(
+          <BaseHeader testMode title={testTitle} headerWidth={testWidth} />
+        );
+        expect(
+          screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
+        ).toHaveClass("rvt-container-" + testWidth);
+      });
+
+      it("should support the fluid width", () => {
+        render(<BaseHeader testMode title={testTitle} headerWidth="fluid" />);
+        expect(
+          screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
+        ).toHaveClass("rvt-p-lr-md");
+      });
     });
 
     it("should render all provided children", () => {
@@ -107,11 +118,11 @@ describe("<BaseHeader />", () => {
   });
 
   describe("Defaulting props", () => {
-    it("should apply to the container div a rivet class that defaults the width to xl, if width is not provided", () => {
+    it("should apply to the container div a rivet class that defaults the width to fluid, if width is not provided", () => {
       render(<BaseHeader testMode title={testTitle} />);
       expect(
         screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
-      ).toHaveClass("rvt-container-xl");
+      ).toHaveClass("rvt-p-lr-md");
     });
   });
 });

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -22,13 +22,15 @@ const Header = ({
   className,
   title,
   subtitle,
-  headerWidth = "xl",
+  headerWidth = "fluid",
   href = "#",
   navigation,
   search,
   secondaryNavigation,
   ...attrs
 }) => {
+  const widthClass =
+    headerWidth === "fluid" ? "rvt-p-lr-md" : "rvt-container-" + headerWidth;
   return (
     <header {...attrs} className={classNames(componentClass, className)}>
       <a
@@ -40,7 +42,7 @@ const Header = ({
       </a>
       <div className="rvt-header-global">
         <div
-          className={"rvt-container-" + headerWidth}
+          className={widthClass}
           data-testid={TestUtils.Header.headerWidthDivTestId}
         >
           <div className="rvt-header-global__inner">
@@ -98,6 +100,7 @@ Header.propTypes = {
     "xxl",
     "3-xl",
     "4-xl",
+    "fluid",
   ]),
   /** The primary navigation component */
   navigation: PropTypes.element,

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -48,11 +48,20 @@ describe("<Header />", () => {
       );
     });
 
-    it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
-      render(<Header title={testTitle} headerWidth={testWidth} />);
-      expect(
-        screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
-      ).toHaveClass("rvt-container-" + testWidth);
+    describe("Header width", () => {
+      it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
+        render(<Header title={testTitle} headerWidth={testWidth} />);
+        expect(
+          screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
+        ).toHaveClass("rvt-container-" + testWidth);
+      });
+
+      it("should apply to the fluid div a rivet class specifying if the fluid width is provided", () => {
+        render(<Header title={testTitle} headerWidth="fluid" />);
+        expect(
+          screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
+        ).toHaveClass("rvt-p-lr-md");
+      });
     });
 
     it("should render all provided children", () => {
@@ -130,11 +139,11 @@ describe("<Header />", () => {
       );
     });
 
-    it("should apply to the container div a rivet class that defaults the width to xl, if width is not provided", () => {
+    it("should apply the rivet class that defaults the width to fluid, if width is not provided", () => {
       render(<Header title={testTitle} />);
       expect(
         screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
-      ).toHaveClass("rvt-container-xl");
+      ).toHaveClass("rvt-p-lr-md");
     });
   });
 });


### PR DESCRIPTION
Fluid headers will likely be desirable for dynamic applications so set them as the default, but support containerized widths for more static content.

Closes #464 