### PR TITLE
feat: #467 make content href customizable

### DIFF
--- a/src/components/Header/BaseHeader.jsx
+++ b/src/components/Header/BaseHeader.jsx
@@ -13,6 +13,7 @@ import { TestUtils } from "../util/TestUtils";
 const BaseHeader = ({
   children,
   className,
+  contentHref,
   title,
   subtitle,
   headerWidth = "fluid",
@@ -38,7 +39,7 @@ const BaseHeader = ({
     <header {...attrs} className={classNames("rvt-header-wrapper", className)}>
       <a
         className="rvt-header-wrapper__skip-link"
-        href={`${document.url}#main-content`}
+        href={contentHref}
         {...(testMode && { "data-testid": TestUtils.Header.skipLinkTestId })}
       >
         Skip to main content
@@ -89,6 +90,8 @@ BaseHeader.displayName = "BaseHeader";
 BaseHeader.propTypes = {
   /** The application name or title that appears in the header */
   title: PropTypes.string.isRequired,
+  /** The href to use for the skip to content link */
+  contentHref: PropTypes.string.isRequired,
   /** Optional subTitle that will be displayed below the title */
   subtitle: PropTypes.string,
   /** The navigation url for the application titles */

--- a/src/components/Header/BaseHeader.jsx
+++ b/src/components/Header/BaseHeader.jsx
@@ -38,7 +38,7 @@ const BaseHeader = ({
     <header {...attrs} className={classNames("rvt-header-wrapper", className)}>
       <a
         className="rvt-header-wrapper__skip-link"
-        href="#main-content"
+        href={`${document.url}#main-content`}
         {...(testMode && { "data-testid": TestUtils.Header.skipLinkTestId })}
       >
         Skip to main content

--- a/src/components/Header/BaseHeader.test.jsx
+++ b/src/components/Header/BaseHeader.test.jsx
@@ -20,11 +20,18 @@ const testWidth = "md";
 
 describe("<BaseHeader />", () => {
   describe("Rendering and styling", () => {
+    beforeAll(() => {
+      Object.defineProperty(window, "location", {
+        value: new URL("https://yourtesturl.com/some-path"),
+        writable: true,
+      });
+    });
+
     it("should render a skip link", () => {
       render(<BaseHeader testMode title={testTitle} />);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
-      ).toHaveAttribute("href", "#main-content");
+      ).toHaveAttribute("href", `${document.url}#main-content`);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
       ).toHaveTextContent("Skip to main content");

--- a/src/components/Header/BaseHeader.test.jsx
+++ b/src/components/Header/BaseHeader.test.jsx
@@ -14,24 +14,20 @@ import BaseHeaderNavigationSecondary from "./BaseHeaderNavigationSecondary";
 import { TestUtils } from "../util/TestUtils";
 
 const testTitle = "Test title";
+const testContentHref = "#main-content";
 const testHref = "/testHref";
 const testSubTitle = "Test Sub title";
 const testWidth = "md";
 
 describe("<BaseHeader />", () => {
   describe("Rendering and styling", () => {
-    beforeAll(() => {
-      Object.defineProperty(window, "location", {
-        value: new URL("https://yourtesturl.com/some-path"),
-        writable: true,
-      });
-    });
-
     it("should render a skip link", () => {
-      render(<BaseHeader testMode title={testTitle} />);
+      render(
+        <BaseHeader testMode title={testTitle} contentHref={testContentHref} />
+      );
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
-      ).toHaveAttribute("href", `${document.url}#main-content`);
+      ).toHaveAttribute("href", testContentHref);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
       ).toHaveTextContent("Skip to main content");

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -35,7 +35,7 @@ const Header = ({
     <header {...attrs} className={classNames(componentClass, className)}>
       <a
         className="rvt-header-wrapper__skip-link"
-        href="#main-content"
+        href={`${document.url}#main-content`}
         data-testid={TestUtils.Header.skipLinkTestId}
       >
         Skip to main content

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -20,6 +20,7 @@ const componentClass = "rvt-header-wrapper";
 const Header = ({
   children,
   className,
+  contentHref,
   title,
   subtitle,
   headerWidth = "fluid",
@@ -35,7 +36,7 @@ const Header = ({
     <header {...attrs} className={classNames(componentClass, className)}>
       <a
         className="rvt-header-wrapper__skip-link"
-        href={`${document.url}#main-content`}
+        href={contentHref}
         data-testid={TestUtils.Header.skipLinkTestId}
       >
         Skip to main content
@@ -85,6 +86,8 @@ Header.displayName = "Header";
 Header.propTypes = {
   /** The application name or title that appears in the header */
   title: PropTypes.string.isRequired,
+  /** The href to use for the skip to content link */
+  contentHref: PropTypes.string.isRequired,
   /** Optional subTitle that will be displayed below the title */
   subtitle: PropTypes.string,
   /** The URL that the anchor towards the left of the header will point to */

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -10,24 +10,18 @@ import Header from "./Header";
 import { TestUtils } from "../util/TestUtils";
 
 const testTitle = "Test title";
+const testContentHref = "#main-content";
 const testHref = "/testHref";
 const testSubTitle = "Test Sub title";
 const testWidth = "md";
 
 describe("<Header />", () => {
   describe("Rendering and styling", () => {
-    beforeAll(() => {
-      Object.defineProperty(window, "location", {
-        value: new URL("https://yourtesturl.com/some-path"),
-        writable: true,
-      });
-    });
-
     it("should render a skip link", () => {
-      render(<Header title={testTitle} />);
+      render(<Header title={testTitle} contentHref={testContentHref} />);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
-      ).toHaveAttribute("href", `${document.url}#main-content`);
+      ).toHaveAttribute("href", testContentHref);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
       ).toHaveTextContent("Skip to main content");

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -16,11 +16,18 @@ const testWidth = "md";
 
 describe("<Header />", () => {
   describe("Rendering and styling", () => {
+    beforeAll(() => {
+      Object.defineProperty(window, "location", {
+        value: new URL("https://yourtesturl.com/some-path"),
+        writable: true,
+      });
+    });
+
     it("should render a skip link", () => {
       render(<Header title={testTitle} />);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
-      ).toHaveAttribute("href", "#main-content");
+      ).toHaveAttribute("href", `${document.url}#main-content`);
       expect(
         screen.getByTestId(TestUtils.Header.skipLinkTestId)
       ).toHaveTextContent("Skip to main content");


### PR DESCRIPTION
Make the content href a required property on `Header` and `BaseHeader` so it is enforced that users set it consciously.