### PR TITLE
feat: Add onClick behavior to BaseHeader and BaseHeaderMenuItem components - closes #471

### DIFF
--- a/src/components/Header/BaseHeader.jsx
+++ b/src/components/Header/BaseHeader.jsx
@@ -36,6 +36,12 @@ const BaseHeader = ({
       </div>
     </>
   );
+  const homeUrlOnClick = onClick
+    ? (e) => {
+        e.preventDefault();
+        onClick(e);
+      }
+    : null;
   return (
     <header {...attrs} className={classNames("rvt-header-wrapper", className)}>
       <a
@@ -58,7 +64,7 @@ const BaseHeader = ({
                 <a
                   className="rvt-lockup"
                   href={homeUrl}
-                  onClick={onClick}
+                  onClick={homeUrlOnClick}
                   {...(testMode && {
                     "data-testid": TestUtils.Header.anchorTestId,
                   })}
@@ -94,7 +100,7 @@ BaseHeader.propTypes = {
   title: PropTypes.string.isRequired,
   /** The href to use for the skip to content link */
   contentHref: PropTypes.string.isRequired,
-  /** Optional onClick handler that will be applied to the homeUrl anchor tag */
+  /** Optional onClick handler that will be applied to the homeUrl anchor tag, it will prevent the anchor tag's default behavior */
   onClick: PropTypes.func,
   /** Optional subTitle that will be displayed below the title */
   subtitle: PropTypes.string,

--- a/src/components/Header/BaseHeader.jsx
+++ b/src/components/Header/BaseHeader.jsx
@@ -14,6 +14,7 @@ const BaseHeader = ({
   children,
   className,
   contentHref,
+  onClick,
   title,
   subtitle,
   headerWidth = "fluid",
@@ -57,6 +58,7 @@ const BaseHeader = ({
                 <a
                   className="rvt-lockup"
                   href={homeUrl}
+                  onClick={onClick}
                   {...(testMode && {
                     "data-testid": TestUtils.Header.anchorTestId,
                   })}
@@ -92,6 +94,8 @@ BaseHeader.propTypes = {
   title: PropTypes.string.isRequired,
   /** The href to use for the skip to content link */
   contentHref: PropTypes.string.isRequired,
+  /** Optional onClick handler that will be applied to the homeUrl anchor tag */
+  onClick: PropTypes.func,
   /** Optional subTitle that will be displayed below the title */
   subtitle: PropTypes.string,
   /** The navigation url for the application titles */

--- a/src/components/Header/BaseHeader.md
+++ b/src/components/Header/BaseHeader.md
@@ -18,7 +18,7 @@ Base component for constructing a header. Can contain multiple subcomponents as 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader homeUrl="/example" onClick={e => { e.preventDefault(); alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) }} title="Application Title" headerWidth="md"/>
+<BaseHeader homeUrl="/example" onClick={e => alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) } title="Application Title" headerWidth="md"/>
 ```
 <!-- prettier-ignore-end -->
 

--- a/src/components/Header/BaseHeader.md
+++ b/src/components/Header/BaseHeader.md
@@ -14,6 +14,14 @@ Base component for constructing a header. Can contain multiple subcomponents as 
 ```
 <!-- prettier-ignore-end -->
 
+### Header with homeUrl and onClick handler
+
+<!-- prettier-ignore-start -->
+```jsx
+<BaseHeader homeUrl="/example" onClick={e => { e.preventDefault(); alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) }} title="Application Title" headerWidth="md"/>
+```
+<!-- prettier-ignore-end -->
+
 ### Header with Primary Navigation and Secondary Navigation
 
 <!-- prettier-ignore-start -->

--- a/src/components/Header/BaseHeader.test.jsx
+++ b/src/components/Header/BaseHeader.test.jsx
@@ -4,6 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 import React from "react";
 import { prettyDOM, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 import BaseHeader from "./BaseHeader";
@@ -53,6 +54,24 @@ describe("<BaseHeader />", () => {
         "href",
         testHref
       );
+    });
+
+    it("should attach an onClick handler to the anchor tag, if provided", async () => {
+      const user = userEvent.setup();
+      const onClick = jest.fn();
+      render(
+        <BaseHeader
+          testMode
+          title={testTitle}
+          homeUrl={testHref}
+          onClick={onClick}
+        />
+      );
+
+      const title = await screen.findByText(testTitle);
+      await user.click(title);
+
+      expect(onClick.mock.calls.length).toBe(1);
     });
 
     describe("Header Width", () => {

--- a/src/components/Header/BaseHeaderMenuItem.jsx
+++ b/src/components/Header/BaseHeaderMenuItem.jsx
@@ -25,6 +25,12 @@ const BaseHeaderMenuItem = ({
     subMenu ? "rvt-header-menu__submenu-item" : "rvt-header-menu__item",
     current ? "rvt-header-menu__item--current" : "",
   ];
+  const itemUrlOnClick = onClick
+    ? (e) => {
+        e.preventDefault();
+        onClick(e);
+      }
+    : null;
   return (
     <li
       className={classNames(classNameArr)}
@@ -40,7 +46,7 @@ const BaseHeaderMenuItem = ({
           }
           {...(current && { "aria-current": "page" })}
           href={itemUrl}
-          onClick={onClick}
+          onClick={itemUrlOnClick}
           {...(testMode && {
             "data-testid": TestUtils.Header.headerMenuItemAnchor,
           })}
@@ -59,7 +65,7 @@ BaseHeaderMenuItem.propTypes = {
   current: PropTypes.bool,
   /** The navigation url for the item */
   itemUrl: PropTypes.string,
-  /** Optional onClick handler for itemUrl anchor tag */
+  /** Optional onClick handler for itemUrl anchor tag, it will prevent the anchor tag's default behavior */
   onClick: PropTypes.func,
   /** Menu item is part of a sub menu */
   subMenu: PropTypes.bool,

--- a/src/components/Header/BaseHeaderMenuItem.jsx
+++ b/src/components/Header/BaseHeaderMenuItem.jsx
@@ -13,29 +13,41 @@ import { TestUtils } from "../util/TestUtils.js";
  * Support component for use primary/secondary navigation components and header menu components.
  */
 const BaseHeaderMenuItem = ({
-  children, current, itemUrl, subMenu = false, testMode = false, ...attrs
+  children,
+  current,
+  onClick,
+  itemUrl,
+  subMenu = false,
+  testMode = false,
+  ...attrs
 }) => {
   const classNameArr = [
     subMenu ? "rvt-header-menu__submenu-item" : "rvt-header-menu__item",
-    current ? "rvt-header-menu__item--current" : ""
-  ]
+    current ? "rvt-header-menu__item--current" : "",
+  ];
   return (
     <li
       className={classNames(classNameArr)}
-      {...(testMode && { "data-testid": TestUtils.Header.headerMenuItemContainer })}
+      {...(testMode && {
+        "data-testid": TestUtils.Header.headerMenuItemContainer,
+      })}
     >
-      {
-        itemUrl &&
-          <a
-            {...attrs}
-            className={subMenu ? "rvt-header-menu__submenu-link" : "rvt-header-menu__link"}
-            {...(current && { "aria-current": "page" })}
-            href={itemUrl}
-            {...(testMode && { "data-testid": TestUtils.Header.headerMenuItemAnchor })}
-          >
-            {children}
-          </a>
-      }
+      {itemUrl && (
+        <a
+          {...attrs}
+          className={
+            subMenu ? "rvt-header-menu__submenu-link" : "rvt-header-menu__link"
+          }
+          {...(current && { "aria-current": "page" })}
+          href={itemUrl}
+          onClick={onClick}
+          {...(testMode && {
+            "data-testid": TestUtils.Header.headerMenuItemAnchor,
+          })}
+        >
+          {children}
+        </a>
+      )}
       {!itemUrl && <>{children}</>}
     </li>
   );
@@ -47,10 +59,12 @@ BaseHeaderMenuItem.propTypes = {
   current: PropTypes.bool,
   /** The navigation url for the item */
   itemUrl: PropTypes.string,
+  /** Optional onClick handler for itemUrl anchor tag */
+  onClick: PropTypes.func,
   /** Menu item is part of a sub menu */
   subMenu: PropTypes.bool,
   /** [Developer] Adds data-testId attributes for component testing */
-  testMode: PropTypes.bool
+  testMode: PropTypes.bool,
 };
 
 export default Rivet.rivetize(BaseHeaderMenuItem);

--- a/src/components/Header/BaseHeaderMenuItem.md
+++ b/src/components/Header/BaseHeaderMenuItem.md
@@ -10,6 +10,9 @@ Header with various menu items:
         <BaseHeaderMenuItem itemUrl="#">
             Link Item
         </BaseHeaderMenuItem>
+        <BaseHeaderMenuItem itemUrl="/example" onClick={e => { e.preventDefault(); alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) }}>
+            Link Item with onClick Handler
+        </BaseHeaderMenuItem>        
         <BaseHeaderMenuItem current itemUrl="#">
             Current Item
         </BaseHeaderMenuItem>

--- a/src/components/Header/BaseHeaderMenuItem.md
+++ b/src/components/Header/BaseHeaderMenuItem.md
@@ -10,7 +10,7 @@ Header with various menu items:
         <BaseHeaderMenuItem itemUrl="#">
             Link Item
         </BaseHeaderMenuItem>
-        <BaseHeaderMenuItem itemUrl="/example" onClick={e => { e.preventDefault(); alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) }}>
+        <BaseHeaderMenuItem itemUrl="/example" onClick={e => alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) }>
             Link Item with onClick Handler
         </BaseHeaderMenuItem>        
         <BaseHeaderMenuItem current itemUrl="#">

--- a/src/components/Header/BaseHeaderMenuItem.test.jsx
+++ b/src/components/Header/BaseHeaderMenuItem.test.jsx
@@ -14,17 +14,15 @@ import userEvent from "@testing-library/user-event";
 const user = userEvent.setup();
 
 describe("<BaseHeaderMenuItem/>", () => {
-  describe("Rendering and styling",  () => {
+  describe("Rendering and styling", () => {
     it("should render default with provided children", () => {
-      render(
-        <BaseHeaderMenuItem testMode>
-          Test text
-        </BaseHeaderMenuItem>
+      render(<BaseHeaderMenuItem testMode>Test text</BaseHeaderMenuItem>);
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
       expect(container).toHaveClass("rvt-header-menu__item");
-      expect(container.nodeName).toBe("LI")
-      expect(container.innerHTML).toBe("Test text")
+      expect(container.nodeName).toBe("LI");
+      expect(container.innerHTML).toBe("Test text");
     });
 
     it("should render as link with provided children", () => {
@@ -33,16 +31,33 @@ describe("<BaseHeaderMenuItem/>", () => {
           Test text
         </BaseHeaderMenuItem>
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
-      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor)
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
+      );
+      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor);
       expect(container).toHaveClass("rvt-header-menu__item");
-      expect(container.nodeName).toBe("LI")
+      expect(container.nodeName).toBe("LI");
 
       expect(anchor).toHaveClass("rvt-header-menu__link");
-      expect(anchor.nodeName).toBe("A")
+      expect(anchor.nodeName).toBe("A");
       expect(anchor).toHaveAttribute("href", "/testHref");
       expect(anchor).not.toHaveAttribute("aria-current");
-      expect(anchor.innerHTML).toBe("Test text")
+      expect(anchor.innerHTML).toBe("Test text");
+    });
+
+    it("should attach onClick handler to itemUrl anchor tag if provided", async () => {
+      const testLabel = "Test label";
+      const onClick = jest.fn();
+      render(
+        <BaseHeaderMenuItem testMode itemUrl="/testHref" onClick={onClick}>
+          {testLabel}
+        </BaseHeaderMenuItem>
+      );
+
+      const label = await screen.findByText(testLabel);
+      await user.click(label);
+
+      expect(onClick.mock.calls.length).toBe(1);
     });
 
     it("should render as link with current page indicators", () => {
@@ -51,47 +66,53 @@ describe("<BaseHeaderMenuItem/>", () => {
           Test text
         </BaseHeaderMenuItem>
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
-      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor)
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
+      );
+      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor);
       expect(container).toHaveClass("rvt-header-menu__item");
-      expect(container.nodeName).toBe("LI")
+      expect(container.nodeName).toBe("LI");
 
       expect(anchor).toHaveClass("rvt-header-menu__link");
-      expect(anchor.nodeName).toBe("A")
+      expect(anchor.nodeName).toBe("A");
       expect(anchor).toHaveAttribute("href", "/testHref");
       expect(anchor).toHaveAttribute("aria-current", "page");
-      expect(anchor.innerHTML).toBe("Test text")
+      expect(anchor.innerHTML).toBe("Test text");
     });
   });
 
-  describe("Rendering and styling as submenu ",  () => {
+  describe("Rendering and styling as submenu ", () => {
     it("should render with provided children", () => {
       render(
         <BaseHeaderMenuItem testMode subMenu>
           Test text
         </BaseHeaderMenuItem>
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
+      );
       expect(container).toHaveClass("rvt-header-menu__submenu-item");
-      expect(container.nodeName).toBe("LI")
-      expect(container.innerHTML).toBe("Test text")
+      expect(container.nodeName).toBe("LI");
+      expect(container.innerHTML).toBe("Test text");
     });
-  
+
     it("should render as link with provided children", () => {
       render(
         <BaseHeaderMenuItem testMode subMenu itemUrl="/testHref">
           Test text
         </BaseHeaderMenuItem>
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
-      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor)
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
+      );
+      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor);
       expect(container).toHaveClass("rvt-header-menu__submenu-item");
-      expect(container.nodeName).toBe("LI")
-  
+      expect(container.nodeName).toBe("LI");
+
       expect(anchor).toHaveClass("rvt-header-menu__submenu-link");
-      expect(anchor.nodeName).toBe("A")
+      expect(anchor.nodeName).toBe("A");
       expect(anchor).toHaveAttribute("href", "/testHref");
-      expect(anchor.innerHTML).toBe("Test text")
+      expect(anchor.innerHTML).toBe("Test text");
     });
 
     it("should render as link with current page indicators", () => {
@@ -100,16 +121,18 @@ describe("<BaseHeaderMenuItem/>", () => {
           Test text
         </BaseHeaderMenuItem>
       );
-      const container = screen.getByTestId(TestUtils.Header.headerMenuItemContainer)
-      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor)
+      const container = screen.getByTestId(
+        TestUtils.Header.headerMenuItemContainer
+      );
+      const anchor = screen.getByTestId(TestUtils.Header.headerMenuItemAnchor);
       expect(container).toHaveClass("rvt-header-menu__submenu-item");
-      expect(container.nodeName).toBe("LI")
+      expect(container.nodeName).toBe("LI");
 
       expect(anchor).toHaveClass("rvt-header-menu__submenu-link");
-      expect(anchor.nodeName).toBe("A")
+      expect(anchor.nodeName).toBe("A");
       expect(anchor).toHaveAttribute("href", "/testHref");
       expect(anchor).toHaveAttribute("aria-current", "page");
-      expect(anchor.innerHTML).toBe("Test text")
+      expect(anchor.innerHTML).toBe("Test text");
     });
   });
 });

--- a/src/components/PageContent/Card/Card.jsx
+++ b/src/components/PageContent/Card/Card.jsx
@@ -32,12 +32,17 @@ const Card = ({
     raised ? "rvt-card--raised " : "",
     className,
   ];
-
+  const cardOnClick = onClick
+    ? (e) => {
+        e.preventDefault();
+        onClick(e);
+      }
+    : null;
   return (
     <Component
       className={classNames(classNameArr)}
-      onClick={clickable && onClick ? onClick : null}
-      style={clickable && onClick ? { cursor: "pointer" } : null}
+      onClick={clickable && cardOnClick ? cardOnClick : null}
+      style={clickable && cardOnClick ? { cursor: "pointer" } : null}
       {...(testMode && { "data-testid": TestUtils.Card.container })}
       {...attrs}
     >
@@ -49,11 +54,11 @@ const Card = ({
           {...(testMode && { "data-testid": TestUtils.Card.title })}
         >
           {titleUrl ? (
-            <a href={titleUrl} onClick={onClick}>
+            <a href={titleUrl} onClick={cardOnClick}>
               {title}
             </a>
-          ) : onClick ? (
-            <Button onClick={onClick} variant="plain">
+          ) : cardOnClick ? (
+            <Button onClick={cardOnClick} variant="plain">
               {title}
             </Button>
           ) : (

--- a/src/components/PageContent/Card/Card.md
+++ b/src/components/PageContent/Card/Card.md
@@ -88,7 +88,7 @@ View the [Rivet documentation for Card](https://rivet.uits.iu.edu/components/car
     <Card
         image={image}
         title="Card with onClick handler"
-        onClick={e => {e.preventDefault(); alert('clicked');}}
+        onClick={e => alert('clicked')}
         meta={meta}
     >
         <p>Using an onClick handler. This can be used with things such as react-router's navigate function.</p>


### PR DESCRIPTION
Adding onClick handlers to a couple components so that we can override the default behavior in their nested anchor tags and use, for example, `react-router`'s `navigate()` function.