### PR TITLE
fix: fix test warnings and update badge modifier property name

### DIFF
--- a/src/components/Header/BaseHeader.test.jsx
+++ b/src/components/Header/BaseHeader.test.jsx
@@ -35,21 +35,35 @@ describe("<BaseHeader />", () => {
     });
 
     it("should render with the title, if title is provided", () => {
-      render(<BaseHeader testMode title={testTitle} />);
+      render(<BaseHeader testMode contentHref="#" title={testTitle} />);
       expect(
         screen.getByTestId(TestUtils.Header.anchorTestId)
       ).toHaveTextContent(testTitle);
     });
 
     it("should render with the subtitle, if subtitle is provided", () => {
-      render(<BaseHeader testMode title={testTitle} subtitle={testSubTitle} />);
+      render(
+        <BaseHeader
+          testMode
+          contentHref="#"
+          title={testTitle}
+          subtitle={testSubTitle}
+        />
+      );
       expect(
         screen.getByTestId(TestUtils.Header.anchorTestId)
       ).toHaveTextContent(testSubTitle);
     });
 
     it("should render an anchor with the provided href, if href is provided", () => {
-      render(<BaseHeader testMode title={testTitle} homeUrl={testHref} />);
+      render(
+        <BaseHeader
+          testMode
+          contentHref="#"
+          title={testTitle}
+          homeUrl={testHref}
+        />
+      );
       expect(screen.getByTestId(TestUtils.Header.anchorTestId)).toHaveAttribute(
         "href",
         testHref
@@ -63,6 +77,7 @@ describe("<BaseHeader />", () => {
         <BaseHeader
           testMode
           title={testTitle}
+          contentHref="#"
           homeUrl={testHref}
           onClick={onClick}
         />
@@ -77,7 +92,12 @@ describe("<BaseHeader />", () => {
     describe("Header Width", () => {
       it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
         render(
-          <BaseHeader testMode title={testTitle} headerWidth={testWidth} />
+          <BaseHeader
+            testMode
+            title={testTitle}
+            contentHref="#"
+            headerWidth={testWidth}
+          />
         );
         expect(
           screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
@@ -85,7 +105,14 @@ describe("<BaseHeader />", () => {
       });
 
       it("should support the fluid width", () => {
-        render(<BaseHeader testMode title={testTitle} headerWidth="fluid" />);
+        render(
+          <BaseHeader
+            testMode
+            title={testTitle}
+            contentHref="#"
+            headerWidth="fluid"
+          />
+        );
         expect(
           screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
         ).toHaveClass("rvt-p-lr-md");
@@ -105,7 +132,11 @@ describe("<BaseHeader />", () => {
       );
 
       render(
-        <BaseHeader title={testTitle} secondaryNavigation={secondaryNavigation}>
+        <BaseHeader
+          title={testTitle}
+          contentHref="#"
+          secondaryNavigation={secondaryNavigation}
+        >
           <BaseHeaderNavigation>
             <BaseHeaderMenuItem itemUrl="#">Nav item one</BaseHeaderMenuItem>
             <BaseHeaderMenuItem itemUrl="#">Nav item two</BaseHeaderMenuItem>
@@ -141,7 +172,7 @@ describe("<BaseHeader />", () => {
 
   describe("Defaulting props", () => {
     it("should apply to the container div a rivet class that defaults the width to fluid, if width is not provided", () => {
-      render(<BaseHeader testMode title={testTitle} />);
+      render(<BaseHeader testMode title={testTitle} contentHref="#" />);
       expect(
         screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
       ).toHaveClass("rvt-p-lr-md");

--- a/src/components/Header/Header.test.jsx
+++ b/src/components/Header/Header.test.jsx
@@ -28,21 +28,23 @@ describe("<Header />", () => {
     });
 
     it("should render an anchor with the title, if title is provided", () => {
-      render(<Header title={testTitle} />);
+      render(<Header title={testTitle} contentHref="#" />);
       expect(
         screen.getByTestId(TestUtils.Header.anchorTestId)
       ).toHaveTextContent(testTitle);
     });
 
     it("should render an anchor with the subtitle, if subtitle is provided", () => {
-      render(<Header title={testTitle} subtitle={testSubTitle} />);
+      render(
+        <Header title={testTitle} contentHref="#" subtitle={testSubTitle} />
+      );
       expect(
         screen.getByTestId(TestUtils.Header.anchorTestId)
       ).toHaveTextContent(testSubTitle);
     });
 
     it("should render an anchor with the provided href, if href is provided", () => {
-      render(<Header title={testTitle} href={testHref} />);
+      render(<Header title={testTitle} contentHref="#" href={testHref} />);
       expect(screen.getByTestId(TestUtils.Header.anchorTestId)).toHaveAttribute(
         "href",
         testHref
@@ -51,14 +53,18 @@ describe("<Header />", () => {
 
     describe("Header width", () => {
       it("should apply to the container div a rivet class specifying the width, if width is provided", () => {
-        render(<Header title={testTitle} headerWidth={testWidth} />);
+        render(
+          <Header title={testTitle} contentHref="#" headerWidth={testWidth} />
+        );
         expect(
           screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
         ).toHaveClass("rvt-container-" + testWidth);
       });
 
       it("should apply to the fluid div a rivet class specifying if the fluid width is provided", () => {
-        render(<Header title={testTitle} headerWidth="fluid" />);
+        render(
+          <Header title={testTitle} contentHref="#" headerWidth="fluid" />
+        );
         expect(
           screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
         ).toHaveClass("rvt-p-lr-md");
@@ -106,6 +112,7 @@ describe("<Header />", () => {
       render(
         <Header
           title={testTitle}
+          contentHref="#"
           navigation={navigation}
           search={search}
           secondaryNavigation={secondaryNavigation}
@@ -133,7 +140,7 @@ describe("<Header />", () => {
 
   describe("Defaulting props", () => {
     it("should render an anchor with the default href, if href is not provided", () => {
-      render(<Header title={testTitle} />);
+      render(<Header title={testTitle} contentHref="#" />);
       expect(screen.getByTestId(TestUtils.Header.anchorTestId)).toHaveAttribute(
         "href",
         "#"
@@ -141,7 +148,7 @@ describe("<Header />", () => {
     });
 
     it("should apply the rivet class that defaults the width to fluid, if width is not provided", () => {
-      render(<Header title={testTitle} />);
+      render(<Header title={testTitle} contentHref="#" />);
       expect(
         screen.getByTestId(TestUtils.Header.headerWidthDivTestId)
       ).toHaveClass("rvt-p-lr-md");

--- a/src/components/PageContent/Badge/Badge.jsx
+++ b/src/components/PageContent/Badge/Badge.jsx
@@ -30,7 +30,7 @@ const Badge = ({
   children,
   className,
   id = Rivet.shortuid(),
-  type: modifier,
+  modifier,
   variant,
   ...attrs
 }) => (

--- a/src/components/PageContent/Badge/Badge.test.jsx
+++ b/src/components/PageContent/Badge/Badge.test.jsx
@@ -29,7 +29,7 @@ describe("<Badge />", () => {
 
     it("should render the appropriate role", () => {
       render(
-        <Badge type="secondary" data-testid={badgeTestId}>
+        <Badge modifier="secondary" data-testid={badgeTestId}>
           Secondary
         </Badge>
       );
@@ -40,7 +40,7 @@ describe("<Badge />", () => {
 
     it("should render combinations of variant and role", () => {
       render(
-        <Badge variant="success" type="secondary" data-testid={badgeTestId}>
+        <Badge variant="success" modifier="secondary" data-testid={badgeTestId}>
           Success secondary
         </Badge>
       );

--- a/src/components/Sidenav/Sidenav.test.jsx
+++ b/src/components/Sidenav/Sidenav.test.jsx
@@ -404,7 +404,7 @@ describe("<SidenavMenu />", () => {
     const onClick = jest.fn();
     const linkText = "Link Text";
     render(
-      <Sidenav>
+      <Sidenav label={sideNavLabel}>
         <Sidenav.Item url="#" onClick={onClick}>
           {linkText}
         </Sidenav.Item>


### PR DESCRIPTION
The `Badge` property `type` is a reserved keyword and does not match the rest of the components which have modifiers.