### PR TITLE
fix: #401 add dialog role to all dialogs

### DIFF
--- a/src/components/Dialog/Dialog.jsx
+++ b/src/components/Dialog/Dialog.jsx
@@ -144,6 +144,7 @@ const Dialog = ({
         <div
           style={{
             position: "fixed",
+            role: "dialog",
             zIndex: 100,
             top: 0,
             left: 0,

--- a/src/components/Dialog/Dialog.md
+++ b/src/components/Dialog/Dialog.md
@@ -135,7 +135,7 @@ const DialogExample = () => {
               <ul className="rvt-list-inline">
                 <li>
                   <div className="rvt-checkbox">
-                    <input type="checkbox" name="checkbox-demo" id="checkbox-1" checked />
+                    <input type="checkbox" name="checkbox-demo" id="checkbox-1" defaultChecked />
                     <label htmlFor="checkbox-1">Option one</label>
                   </div>
                 </li>


### PR DESCRIPTION
The `dialog` role is not currently being applied to dialogs when `disablePageInteraction` is set.