### PR TITLE
fix: #475 fix header navigation child key warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@react-aria/utils": "3.26.0",
         "classnames": "2.5.1",
         "rivet-core": "2.8.1",
-        "rivet-icons": "3.0.0"
+        "rivet-icons": "3.0.0",
+        "uuid": "11.0.4"
       },
       "devDependencies": {
         "@babel/core": "7.26.0",
@@ -11460,6 +11461,16 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -19700,6 +19711,16 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -20824,12 +20845,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
+      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -29385,6 +29410,14 @@
         "strip-ansi": "^6.0.1",
         "uuid": "^8.3.2",
         "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "jest-leak-detector": {
@@ -35159,6 +35192,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "source-list-map": {
@@ -35959,10 +36000,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.4.tgz",
+      "integrity": "sha512-IzL6VtTTYcAhA/oghbFJ1Dkmqev+FpQWnCBaKq/gUluLxliWvO8DPFWfIviRmYbtaavtSQe4WBL++rFjdcGWEg=="
     },
     "v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,8 @@
     "@react-aria/utils": "3.26.0",
     "classnames": "2.5.1",
     "rivet-core": "2.8.1",
-    "rivet-icons": "3.0.0"
+    "rivet-icons": "3.0.0",
+    "uuid": "11.0.4"
   },
   "peerDependencies": {
     "react": ">= 16",

--- a/src/components/Header/BaseHeader.md
+++ b/src/components/Header/BaseHeader.md
@@ -2,7 +2,7 @@ Base component for constructing a header. Can contain multiple subcomponents as 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title" />
+<BaseHeader title="Application Title" contentHref="#" />
 ```
 <!-- prettier-ignore-end -->
 
@@ -10,7 +10,7 @@ Base component for constructing a header. Can contain multiple subcomponents as 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title" subtitle="Optional subtitle" headerWidth="md"/>
+<BaseHeader title="Application Title" contentHref="#" subtitle="Optional subtitle" headerWidth="md"/>
 ```
 <!-- prettier-ignore-end -->
 
@@ -18,7 +18,7 @@ Base component for constructing a header. Can contain multiple subcomponents as 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader homeUrl="/example" onClick={e => alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) } title="Application Title" headerWidth="md"/>
+<BaseHeader homeUrl="/example" onClick={e => alert(`You could navigate to ${e.currentTarget.attributes.href.nodeValue}`) } title="Application Title" contentHref="#" headerWidth="md"/>
 ```
 <!-- prettier-ignore-end -->
 
@@ -31,7 +31,7 @@ const secondaryNav = <BaseHeaderNavigationSecondary title="Components">
     <BaseHeaderMenuItem itemUrl="#">Sub item two</BaseHeaderMenuItem>
 </BaseHeaderNavigationSecondary>;
 
-<BaseHeader title="Application Title" secondaryNavigation={secondaryNav}>
+<BaseHeader title="Application Title" contentHref="#" secondaryNavigation={secondaryNav}>
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem itemUrl="#">Nav item one</BaseHeaderMenuItem>
         <BaseHeaderMenuItem itemUrl="#">Nav item two</BaseHeaderMenuItem>
@@ -57,6 +57,7 @@ const secondaryNavigation = <BaseHeaderNavigationSecondary title="Component Libr
 
 <BaseHeader
     homeUrl="/foo"
+    contentHref="#"
     secondaryNavigation={secondaryNavigation}
     title="Application Title"
 >

--- a/src/components/Header/BaseHeaderMenu.md
+++ b/src/components/Header/BaseHeaderMenu.md
@@ -2,7 +2,7 @@ Base component for adding a dropdown menu to primary or secondary navigation in 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title">
+<BaseHeader title="Application Title" contentHref="#">
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem>
             <BaseHeaderMenu label="Nav item one">
@@ -20,7 +20,7 @@ Base component for adding a dropdown menu to primary or secondary navigation in 
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title">
+<BaseHeader title="Application Title" contentHref="#">
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem>
             <BaseHeaderMenu label="Nav item one" menuUrl="#">

--- a/src/components/Header/BaseHeaderMenuItem.md
+++ b/src/components/Header/BaseHeaderMenuItem.md
@@ -2,7 +2,7 @@ Header with various menu items:
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Header Menu Items">
+<BaseHeader title="Header Menu Items" contentHref="#">
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem>
             <Button variant="plain">Standard Item</Button>

--- a/src/components/Header/BaseHeaderNavigation.md
+++ b/src/components/Header/BaseHeaderNavigation.md
@@ -2,7 +2,7 @@ Base component for constructing a primary navigation in the header.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title">
+<BaseHeader title="Application Title" contentHref="#">
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem itemUrl="#">Nav item one</BaseHeaderMenuItem>
         <BaseHeaderMenuItem itemUrl="#">Nav item two</BaseHeaderMenuItem>
@@ -16,7 +16,7 @@ Base component for constructing a primary navigation in the header.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<BaseHeader title="Application Title">
+<BaseHeader title="Application Title" contentHref="#">
     <BaseHeaderNavigation>
         <BaseHeaderMenuItem>
             <BaseHeaderMenu label="Nav item one">

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -64,8 +64,8 @@ const Header = ({
             </div>
             {(navigation || search) && (
               <div className="rvt-header-global__controls">
-                <>{navigation}</>
-                <>{search}</>
+                {navigation}
+                {search}
               </div>
             )}
           </div>

--- a/src/components/Header/Header.md
+++ b/src/components/Header/Header.md
@@ -6,7 +6,7 @@ View the [Rivet documentation for Header](https://rivet.iu.edu/components/header
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Header title="Application Title" />
+<Header title="Application Title" contentHref="#" />
 ```
 <!-- prettier-ignore-end -->
 
@@ -14,7 +14,7 @@ An optional subtitle can also be provided.
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Header title="Application Title" subtitle="Optional subtitle" />
+<Header title="Application Title" contentHref="#" subtitle="Optional subtitle" />
 ```
 <!-- prettier-ignore-end -->
 
@@ -22,7 +22,7 @@ You can also override the default "/" URL for the link:
 
 <!-- prettier-ignore-start -->
 ```jsx
-<Header title="Application Title" href="/foo" />
+<Header title="Application Title" contentHref="#" href="/foo" />
 ```
 <!-- prettier-ignore-end -->
 
@@ -31,7 +31,7 @@ The width prop can be used to constrain the width of the header.
 <!-- prettier-ignore-start -->
 
 ```jsx
-<Header title="Application Title" headerWidth="md"/>
+<Header title="Application Title" contentHref="#" headerWidth="md"/>
 ```
 <!-- prettier-ignore-end -->
 
@@ -55,7 +55,7 @@ const navigation = <Header.Navigation>
   </ul>
 </Header.Navigation>;
 
-<Header title="Application Title" navigation={navigation} />
+<Header title="Application Title" contentHref="#" navigation={navigation} />
 ```
 <!-- prettier-ignore-end -->
 
@@ -78,7 +78,7 @@ const navigation = <Header.Navigation avatar={avatar}>
   </ul>
 </Header.Navigation>;
 
-<Header title="Application Title" navigation={navigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation}/>
 ```
 <!-- prettier-ignore-end -->
 
@@ -87,7 +87,7 @@ Header with Search:
 <!-- prettier-ignore-start -->
 ```jsx
 const search = <Header.Search action={"/mySearchURL"} method={"post"}/>;
-<Header title="Application Title" search={search} />
+<Header title="Application Title" contentHref="#" search={search} />
 ```
 <!-- prettier-ignore-end -->
 
@@ -110,7 +110,7 @@ const navigation = <Header.Navigation>
 </Header.Navigation>;
 const search = <Header.Search action={"/mySearchURL"} method={"post"}/>;
 
-<Header title="Application Title" navigation={navigation} search={search} />
+<Header title="Application Title" contentHref="#" navigation={navigation} search={search} />
 ```
 <!-- prettier-ignore-end -->
 
@@ -146,7 +146,7 @@ const secondaryNavigation = <Header.NavigationSecondary title={"Component Librar
   </ul>
 </Header.NavigationSecondary>;
 
-<Header title="Application Title" navigation={navigation} search={search} secondaryNavigation={secondaryNavigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation} search={search} secondaryNavigation={secondaryNavigation}/>
 
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Header/HeaderAvatar.md
+++ b/src/components/Header/HeaderAvatar.md
@@ -1,37 +1,41 @@
 Header.Avatar can optionally be included in [Header.Navigation](#/Navigation?id=headernavigation) to show the login details (username and short name) of the user, along with a logout link.
 
 Standard Avatar:
+
 <!-- prettier-ignore-start -->
 ```jsx
 const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} />
 const navigation = <Header.Navigation avatar={avatar} />;
-<Header title="Application Title" navigation={navigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation}/>
 ```
 <!-- prettier-ignore-end -->
 
 Avatar with logout link:
+
 <!-- prettier-ignore-start -->
 ```jsx
 const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"} />
 const navigation = <Header.Navigation avatar={avatar} />;
-<Header title="Application Title" navigation={navigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation}/>
 ```
 <!-- prettier-ignore-end -->
 
 Avatar with logout link with onClick:
+
 <!-- prettier-ignore-start -->
 ```jsx
 const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} logoutURL={"/logout"} logoutClick={() => console.log("logout")}/>
 const navigation = <Header.Navigation avatar={avatar} />;
-<Header title="Application Title" navigation={navigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation}/>
 ```
 <!-- prettier-ignore-end -->
 
 Avatar with logout button:
+
 <!-- prettier-ignore-start -->
 ```jsx
 const avatar = <Header.Avatar username={"johndoe"} shortName={"jd"} logoutClick={() => console.log("logout")}/>
 const navigation = <Header.Navigation avatar={avatar} />;
-<Header title="Application Title" navigation={navigation}/>
+<Header title="Application Title" contentHref="#" navigation={navigation}/>
 ```
 <!-- prettier-ignore-end -->

--- a/src/components/Header/HeaderNavigation.jsx
+++ b/src/components/Header/HeaderNavigation.jsx
@@ -45,7 +45,7 @@ const HeaderNavigation = ({ avatar, children, ...attrs }) => {
   });
 
   const wrappedChildren = useMemo(() => {
-    return React.Children.map(renderHeaderNavUnorderedList);
+    return React.Children.map(children, renderHeaderNavUnorderedList);
   }, [children]);
 
   const toggleNavigation = () => {

--- a/src/components/Header/HeaderNavigation.jsx
+++ b/src/components/Header/HeaderNavigation.jsx
@@ -7,8 +7,9 @@ import * as React from "react";
 import * as Rivet from "../util/Rivet";
 import "rivet-icons/dist/chevron-up.js";
 import "rivet-icons/dist/chevron-down.js";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { handler, isUnhandledKeyPress } from "./HeaderEventUtils";
+import { renderHeaderNavUnorderedList, simplify } from "./childUtils";
 import {
   isEscapeKeyPress,
   isMouseEvent,
@@ -16,7 +17,6 @@ import {
   targets,
 } from "../util/EventUtils";
 import { TestUtils } from "../util/TestUtils";
-import { renderHeaderNavUnorderedList } from "./childUtils";
 import PropTypes from "prop-types";
 
 const shouldToggleNavigation = (event, wrapperDivRef) => {
@@ -43,6 +43,10 @@ const HeaderNavigation = ({ avatar, children, ...attrs }) => {
       eventHandler.deregister();
     };
   });
+
+  const wrappedChildren = useMemo(() => {
+    return React.Children.map(renderHeaderNavUnorderedList);
+  }, [children]);
 
   const toggleNavigation = () => {
     setIsNavMenuOpen(!isNavMenuOpen);
@@ -86,7 +90,7 @@ const HeaderNavigation = ({ avatar, children, ...attrs }) => {
         hidden={!isNavMenuOpen}
         data-testid={TestUtils.Header.headerNavTestId}
       >
-        {React.Children.map(children, renderHeaderNavUnorderedList)}
+        {wrappedChildren}
         {avatar}
       </nav>
     </div>

--- a/src/components/Header/HeaderNavigation.jsx
+++ b/src/components/Header/HeaderNavigation.jsx
@@ -9,7 +9,7 @@ import "rivet-icons/dist/chevron-up.js";
 import "rivet-icons/dist/chevron-down.js";
 import { useEffect, useMemo, useRef } from "react";
 import { handler, isUnhandledKeyPress } from "./HeaderEventUtils";
-import { renderHeaderNavUnorderedList, simplify } from "./childUtils";
+import { renderHeaderNavUnorderedList } from "./childUtils";
 import {
   isEscapeKeyPress,
   isMouseEvent,

--- a/src/components/Header/childUtils.jsx
+++ b/src/components/Header/childUtils.jsx
@@ -4,6 +4,7 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 import * as React from "react";
 import getDisplayName from "react-display-name";
+import { v4 as uuidv4 } from "uuid";
 import { HeaderMenu } from "./index";
 import classNames from "classnames";
 import { TestUtils } from "../util/TestUtils";
@@ -30,9 +31,10 @@ const renderHeaderNavListItem = (child) => {
 
   return (
     <li
+      key={uuidv4()}
       className={classNames(
         "rvt-header-menu__item",
-        isListItemCurrent && "rvt-header-menu__item--current"
+        isListItemCurrent && "rvt-header-menu__item--current",
       )}
       data-testid={TestUtils.Header.navListItemTestId}
     >
@@ -44,12 +46,17 @@ const renderHeaderNavListItem = (child) => {
 export const renderHeaderNavUnorderedList = (child) => {
   const childType = child && child.type;
   if (getDisplayName(childType) === HeaderAvatar.displayName) {
-    return <></>;
+    return <React.Fragment></React.Fragment>;
   }
 
   let listItems = React.Children.map(
     child.props.children,
-    renderHeaderNavListItem
+    renderHeaderNavListItem,
   );
-  return <ul className={"rvt-header-menu__list"}>{listItems}</ul>;
+
+  return (
+    <ul key={uuidv4()} className={"rvt-header-menu__list"}>
+      {listItems}
+    </ul>
+  );
 };

--- a/src/components/PageContent/EmptyState/EmptyState.md
+++ b/src/components/PageContent/EmptyState/EmptyState.md
@@ -39,7 +39,7 @@ View the [Rivet documentation for EmptyState](https://rivet.iu.edu/components/em
 <EmptyState>
     <EmptyState.Content>
         <div className="rvt-p-all-md rvt-m-bottom-md rvt-bg-black-100 rvt-inline-flex rvt-border-radius-circle">
-            <Icon name="bell" />       
+            <rvt-icon name="bell" />       
         </div>
         <p>There's nothing here yet.</p>
     </EmptyState.Content>

--- a/src/components/Pagination/Pagination.md
+++ b/src/components/Pagination/Pagination.md
@@ -84,7 +84,7 @@ View the [Rivet documentation for Pagination](https://rivet.iu.edu/components/pa
         ariaLabel="Go to previous page"
         className="rvt-m-lr-sm"
     >
-        <Icon className="rvt-m-right-xs" name="previous" />
+        <rvt-icon className="rvt-m-right-xs" name="previous" />
         Back
     </PaginationItem>
     <PaginationItem
@@ -116,7 +116,7 @@ View the [Rivet documentation for Pagination](https://rivet.iu.edu/components/pa
         className="rvt-m-lr-sm"
     >
         Next
-        <Icon className="rvt-m-left-xs" name="next" />
+        <rvt-icon className="rvt-m-left-xs" name="next" />
     </PaginationItem>
     <PaginationItem
         ariaLabel="Go to last page"

--- a/src/components/Pagination/Pagination.md
+++ b/src/components/Pagination/Pagination.md
@@ -84,7 +84,7 @@ View the [Rivet documentation for Pagination](https://rivet.iu.edu/components/pa
         ariaLabel="Go to previous page"
         className="rvt-m-lr-sm"
     >
-        <rvt-icon className="rvt-m-right-xs" name="previous" />
+        <rvt-icon className="rvt-m-right-xs" name="chevron-left" />
         Back
     </PaginationItem>
     <PaginationItem
@@ -116,7 +116,7 @@ View the [Rivet documentation for Pagination](https://rivet.iu.edu/components/pa
         className="rvt-m-lr-sm"
     >
         Next
-        <rvt-icon className="rvt-m-left-xs" name="next" />
+        <rvt-icon className="rvt-m-left-xs" name="chevron-right" />
     </PaginationItem>
     <PaginationItem
         ariaLabel="Go to last page"

--- a/styleguide.setup.js
+++ b/styleguide.setup.js
@@ -3,5 +3,7 @@ Copyright (C) 2018 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
 */
 import * as rivet from "./src/components/index.js";
+// rivet-icons used only in md files which are not inherent to a component
+import "rivet-icons/dist/bell.js";
 
 Object.assign(globalThis, rivet);


### PR DESCRIPTION
* Use memoized child dependency in HeaderNavigation to determine when children change and key them with a UUID.
* Fix missing contentHref and icons in markdown documentation files.