### PR TITLE
fix: #401 Adjust role fix and add focus handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@react-aria/overlays": "3.24.0",
         "@react-aria/utils": "3.26.0",
         "classnames": "2.5.1",
+        "focus-trap-react": "11.0.2",
         "rivet-core": "2.8.1",
         "rivet-icons": "3.0.0"
       },
@@ -4874,7 +4875,6 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4884,7 +4884,6 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
       "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -7502,8 +7501,7 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "node_modules/data-urls": {
       "version": "3.0.2",
@@ -8825,6 +8823,31 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6.x"
+      }
+    },
+    "node_modules/focus-trap": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "node_modules/focus-trap-react": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.2.tgz",
+      "integrity": "sha512-x9sNgXhaWyq1idKW11pJftDZ3WIWgpXc9aWEU3GmLNjso3RHzyaPCBjxftoEXYJZDoq5iUlLThZ3GUf7csyJBA==",
+      "license": "MIT",
+      "dependencies": {
+        "focus-trap": "^7.6.2",
+        "tabbable": "^6.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/follow-redirects": {
@@ -20086,6 +20109,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
+    },
     "node_modules/tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -24736,7 +24765,6 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
-      "dev": true,
       "requires": {
         "csstype": "^3.0.2"
       }
@@ -24745,7 +24773,6 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
       "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
-      "dev": true,
       "requires": {}
     },
     "@types/react-test-renderer": {
@@ -26646,8 +26673,7 @@
     "csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
     "data-urls": {
       "version": "3.0.2",
@@ -27586,6 +27612,23 @@
           "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ==",
           "dev": true
         }
+      }
+    },
+    "focus-trap": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "requires": {
+        "tabbable": "^6.2.0"
+      }
+    },
+    "focus-trap-react": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-11.0.2.tgz",
+      "integrity": "sha512-x9sNgXhaWyq1idKW11pJftDZ3WIWgpXc9aWEU3GmLNjso3RHzyaPCBjxftoEXYJZDoq5iUlLThZ3GUf7csyJBA==",
+      "requires": {
+        "focus-trap": "^7.6.2",
+        "tabbable": "^6.2.0"
       }
     },
     "follow-redirects": {
@@ -35455,6 +35498,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@react-aria/dialog": "3.5.20",
     "@react-aria/overlays": "3.24.0",
     "@react-aria/utils": "3.26.0",
+    "focus-trap-react": "11.0.2",
     "classnames": "2.5.1",
     "rivet-core": "2.8.1",
     "rivet-icons": "3.0.0"

--- a/src/components/Dialog/Dialog.test.jsx
+++ b/src/components/Dialog/Dialog.test.jsx
@@ -61,10 +61,10 @@ describe("<Dialog />", () => {
       render(component());
       expect(screen.getByRole("dialog", {})).toHaveClass("rvt-dialog");
       expect(
-        screen.getByTestId(TestUtils.Dialog.dialogHeaderTestId, {})
+        screen.getByTestId(TestUtils.Dialog.dialogHeaderTestId, {}),
       ).toHaveClass("rvt-dialog__header");
       expect(await screen.findByText(defaultTitle, {})).toHaveClass(
-        "rvt-dialog__title"
+        "rvt-dialog__title",
       );
     });
 
@@ -77,6 +77,23 @@ describe("<Dialog />", () => {
     it("should display the title", async () => {
       render(component());
       expect(await screen.findByText(defaultTitle, {})).toBeVisible();
+    });
+
+    it("should have dialog role if disable page interaction is true", () => {
+      render(component({ disablePageInteraction: true }));
+      expect(screen.getByRole("dialog", {})).toBeVisible();
+    });
+
+    it("should focus on dialog", () => {
+      render(component());
+      expect(screen.getByRole("dialog", {})).toHaveFocus();
+    });
+
+    it("should focus on dialog if disable page interaction is true", () => {
+      render(component({ disablePageInteraction: true }));
+      expect(
+        screen.getByRole("dialog", {}).parentNode.parentNode,
+      ).toHaveFocus();
     });
 
     it("should update if a prop changes", async () => {
@@ -99,7 +116,7 @@ describe("<Dialog />", () => {
         .getAttribute("aria-labelledby");
       expect(await screen.findByText(defaultTitle, {})).toHaveProperty(
         "id",
-        ariaLabelledby
+        ariaLabelledby,
       );
     });
 
@@ -108,7 +125,7 @@ describe("<Dialog />", () => {
       expect(screen.queryByText(defaultTitle, {})).not.toBeNull();
       expect(screen.getByRole("dialog", {})).toHaveAttribute(
         "aria-hidden",
-        "false"
+        "false",
       );
       expect(screen.getByRole("dialog", {})).not.toHaveAttribute("hidden");
     });
@@ -161,7 +178,7 @@ describe("<Dialog />", () => {
     it("should not align the dialog if property not present", () => {
       render(component());
       expect(screen.getByRole("dialog", {})).not.toHaveAttribute(
-        "data-rvt-dialog"
+        "data-rvt-dialog",
       );
     });
 
@@ -169,7 +186,7 @@ describe("<Dialog />", () => {
       it(`should align ${align} the dialog if property present`, () => {
         render(component({ align: align }));
         expect(screen.getByRole("dialog", {})).toHaveAttribute(
-          `data-rvt-dialog-${align}`
+          `data-rvt-dialog-${align}`,
         );
       });
     };
@@ -183,14 +200,14 @@ describe("<Dialog />", () => {
     it("should not darken the page if property not true", () => {
       render(component());
       expect(screen.getByRole("dialog", {})).not.toHaveAttribute(
-        "data-rvt-dialog-darken-page"
+        "data-rvt-dialog-darken-page",
       );
     });
 
     it("should darken the page if property true", () => {
       render(component({ darkenPage: true }));
       expect(screen.getByRole("dialog", {})).toHaveAttribute(
-        "data-rvt-dialog-darken-page"
+        "data-rvt-dialog-darken-page",
       );
     });
   });
@@ -199,14 +216,14 @@ describe("<Dialog />", () => {
     it("should not disable page interaction if property not true", () => {
       render(component());
       expect(
-        screen.queryByTestId(TestUtils.Dialog.underlayDivTestId, {})
+        screen.queryByTestId(TestUtils.Dialog.underlayDivTestId, {}),
       ).toBeNull();
     });
 
     it("should disable page interaction if property true", () => {
       render(component({ disablePageInteraction: true }));
       expect(
-        screen.getByTestId(TestUtils.Dialog.underlayDivTestId, {})
+        screen.getByTestId(TestUtils.Dialog.underlayDivTestId, {}),
       ).toBeDefined();
     });
   });
@@ -241,7 +258,7 @@ describe("<Dialog />", () => {
           onDismiss,
           closeOnOutsideClickOrEscape: true,
           isOpen: false,
-        })
+        }),
       );
       pressEscapeKey();
       expect(onDismiss).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
I adjusted #480, I believe the role needs to be an attribute instead of as part of style.

For the focus work I settled on adding a new library. Adobe react-aria supports focus trapping (and it works) but I couldn't get it to work in our code base. It probably has to do with the ref object we pass into the library. I tried to replicate the adobe react-aria code but it turned out messy and I called it quits before I got it working. Finally I settled on using focus-trap-react which looks rather clean. Of course it's "one more library"...

Long term I hope we can migrate to HTML5 dialog but as we discussed in the last few days it is not accessibility ready.

Let me know what you think, thanks!