### PR TITLE
fix: #491 fix dialog examples

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx pretty-quick --staged
+npx pretty-quick --staged && npm run license

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "prop-types": "15.8.1",
         "react-display-name": "0.2.5",
         "react-docgen": "7.1.0",
-        "react-styleguidist": "13.1.3",
+        "react-styleguidist": "13.1.4",
         "semantic-release": "24.2.1",
         "style-loader": "4.0.0",
         "vite": "5.4.11",
@@ -18232,9 +18232,9 @@
       }
     },
     "node_modules/react-styleguidist": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-13.1.3.tgz",
-      "integrity": "sha512-3H5AAlzDW7QXuL1k1SzzlSbmEhk+r18t+m5VdUtaI0x1btpl+lDYPtfB+//zlU8ucnis0q2cdxqABsHx20UmaQ==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-13.1.4.tgz",
+      "integrity": "sha512-gRGmvIowrem+xT0mieHmKpt+YYN+UBlmp8gBpoEZbQbx+GA9KJAE/eylaMaT7O8RnzD0BSRYOBvT0IjGQ7+45w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34143,9 +34143,9 @@
       "requires": {}
     },
     "react-styleguidist": {
-      "version": "13.1.3",
-      "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-13.1.3.tgz",
-      "integrity": "sha512-3H5AAlzDW7QXuL1k1SzzlSbmEhk+r18t+m5VdUtaI0x1btpl+lDYPtfB+//zlU8ucnis0q2cdxqABsHx20UmaQ==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/react-styleguidist/-/react-styleguidist-13.1.4.tgz",
+      "integrity": "sha512-gRGmvIowrem+xT0mieHmKpt+YYN+UBlmp8gBpoEZbQbx+GA9KJAE/eylaMaT7O8RnzD0BSRYOBvT0IjGQ7+45w==",
       "dev": true,
       "requires": {
         "@tippyjs/react": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "test-win": "jest",
     "build": "vite build",
     "preview": "vite preview",
-    "prepare": "husky install",
+    "prepare": "husky",
     "pretty-quick": "pretty-quick",
     "publish-guide": "npx styleguidist build --config styleguide.config.cjs && cp -r .circleci styleguide && gh-pages --dist styleguide --dotfiles"
   },
@@ -161,7 +161,7 @@
     "prop-types": "15.8.1",
     "react-display-name": "0.2.5",
     "react-docgen": "7.1.0",
-    "react-styleguidist": "13.1.3",
+    "react-styleguidist": "13.1.4",
     "semantic-release": "24.2.1",
     "style-loader": "4.0.0",
     "vite": "5.4.11",

--- a/src/components/Dialog/Dialog.md
+++ b/src/components/Dialog/Dialog.md
@@ -48,7 +48,10 @@ const DialogExample = () => {
 
   return (
     <>
-      <Button onClick={() => setDialogOpen("default-dialog")}>Default dialog</Button>
+      <Button onClick={event => {
+        setDialogOpen("default-dialog");
+        event.stopPropagation();
+      }}>Default dialog</Button>
       <Dialog
         isOpen={dialogOpen === "default-dialog"}
         onDismiss={handleDismiss}
@@ -65,7 +68,10 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={() => setDialogOpen("modal-dialog")}>Modal dialog</Button>
+      <Button onClick={event => {
+        setDialogOpen("modal-dialog");
+        event.stopPropagation();
+      }}>Modal dialog</Button>
       <Dialog
         isOpen={dialogOpen === "modal-dialog"}
         darkenPage={true}
@@ -84,7 +90,10 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={() => setDialogOpen("confirmation-dialog")}>Confirmation dialog</Button>
+      <Button onClick={event => {
+        setDialogOpen("confirmation-dialog");
+        event.stopPropagation();
+      }}>Confirmation dialog</Button>
       <Dialog
         isOpen={dialogOpen === "confirmation-dialog"}
         disablePageInteraction={true}
@@ -103,7 +112,10 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={() => setDialogOpen("dialog-with-form")}>Dialog with form</Button>
+      <Button onClick={event => {
+        setDialogOpen("dialog-with-form");
+        event.stopPropagation();
+      }}>Dialog with form</Button>
       <Dialog
         isOpen={dialogOpen === "dialog-with-form"}
         darkenPage={true}
@@ -161,7 +173,10 @@ const DialogExample = () => {
         </form>
       </Dialog>
 
-      <Button onClick={() => setDialogOpen("notification")}>Notification</Button>
+      <Button onClick={event => {
+        setDialogOpen("notification");
+        event.stopPropagation();
+      }}>Notification</Button>
       <Dialog
         isOpen={dialogOpen === "notification"}
         align="top-right"
@@ -174,7 +189,10 @@ const DialogExample = () => {
         </DialogBody>
       </Dialog>
 
-      <Button onClick={() => setDialogOpen("help-widget")}>Help widget</Button>
+      <Button onClick={event => {
+        setDialogOpen("help-widget");
+        event.stopPropagation();
+      }}>Help widget</Button>
       <Dialog
         isOpen={dialogOpen === "help-widget"}
         align="bottom-right"

--- a/src/components/Dialog/Dialog.md
+++ b/src/components/Dialog/Dialog.md
@@ -45,13 +45,15 @@ const DialogExample = () => {
   const handleDismiss = () => {
     setDialogOpen(false);
   };
+  const openModal = (event, modalKey) => {
+    setDialogOpen(modalKey);
+    event.preventDefault();
+    event.stopPropagation();
+  };
 
   return (
     <>
-      <Button onClick={event => {
-        setDialogOpen("default-dialog");
-        event.stopPropagation();
-      }}>Default dialog</Button>
+      <Button onClick={event => openModal(event, "default-dialog")}>Default dialog</Button>
       <Dialog
         isOpen={dialogOpen === "default-dialog"}
         onDismiss={handleDismiss}
@@ -68,10 +70,7 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={event => {
-        setDialogOpen("modal-dialog");
-        event.stopPropagation();
-      }}>Modal dialog</Button>
+      <Button onClick={event => openModal(event, "modal-dialog")}>Modal dialog</Button>
       <Dialog
         isOpen={dialogOpen === "modal-dialog"}
         darkenPage={true}
@@ -90,10 +89,7 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={event => {
-        setDialogOpen("confirmation-dialog");
-        event.stopPropagation();
-      }}>Confirmation dialog</Button>
+      <Button onClick={event => openModal(event, "confirmation-dialog")}>Confirmation dialog</Button>
       <Dialog
         isOpen={dialogOpen === "confirmation-dialog"}
         disablePageInteraction={true}
@@ -112,10 +108,7 @@ const DialogExample = () => {
         </DialogControls>
       </Dialog>
 
-      <Button onClick={event => {
-        setDialogOpen("dialog-with-form");
-        event.stopPropagation();
-      }}>Dialog with form</Button>
+      <Button onClick={event => openModal(event, "dialog-with-form")}>Dialog with form</Button>
       <Dialog
         isOpen={dialogOpen === "dialog-with-form"}
         darkenPage={true}
@@ -173,10 +166,7 @@ const DialogExample = () => {
         </form>
       </Dialog>
 
-      <Button onClick={event => {
-        setDialogOpen("notification");
-        event.stopPropagation();
-      }}>Notification</Button>
+      <Button onClick={event => openModal(event, "notification")}>Notification</Button>
       <Dialog
         isOpen={dialogOpen === "notification"}
         align="top-right"
@@ -189,10 +179,7 @@ const DialogExample = () => {
         </DialogBody>
       </Dialog>
 
-      <Button onClick={event => {
-        setDialogOpen("help-widget");
-        event.stopPropagation();
-      }}>Help widget</Button>
+      <Button onClick={event => openModal(event, "help-widget")}>Help widget</Button>
       <Dialog
         isOpen={dialogOpen === "help-widget"}
         align="bottom-right"


### PR DESCRIPTION
In development environments, the modals which allow closing on outside interactions were being immediately closed because the button event which opened them was also triggering a close.