### PR TITLE
chore: EPMDW-3684 - Revert changes to accordion so they can be re-applied properly

### DIFF
--- a/src/components/Accordion/Accordion.test.jsx
+++ b/src/components/Accordion/Accordion.test.jsx
@@ -598,27 +598,6 @@ describe("<AccordionPanel />", () => {
     });
   });
 
-  it("should allow an element for its title prop", () => {
-    const title = <p>accordion panel title</p>;
-    const { container } = render(
-      <Accordion>
-        <AccordionPanel
-          className={customPanelClassName}
-          controlId={controlId}
-          testMode
-          title={title}
-        >
-          content 1
-        </AccordionPanel>
-      </Accordion>,
-    );
-    const header = container
-      .getElementsByClassName("rvt-accordion__toggle-text")
-      .item(0);
-    const headerElement = header.getElementsByTagName("p").item(0);
-    expect(headerElement.innerHTML).toBe("accordion panel title");
-  });
-
   describe("Options", () => {
     it("default is test mode off", () => {
       render(

--- a/src/components/Accordion/AccordionPanel.jsx
+++ b/src/components/Accordion/AccordionPanel.jsx
@@ -36,7 +36,7 @@ AccordionPanel.propTypes = {
   /** [Developer] Adds data-testId attributes for component testing */
   testMode: PropTypes.bool,
   /** The panel's title */
-  title: PropTypes.node.isRequired,
+  title: PropTypes.string.isRequired,
 };
 
 export default Rivet.rivetize(AccordionPanel);


### PR DESCRIPTION
The commit type was `feature:` instead of `feat:` so a release was not triggered. This PR will be followed by another PR to re-apply the changes with the proper commit type.