### PR TITLE
feat: EPMDW-3684 - Allow node for AccordionPanel title prop - Closes #537

### DIFF
--- a/src/components/Accordion/Accordion.test.jsx
+++ b/src/components/Accordion/Accordion.test.jsx
@@ -598,6 +598,27 @@ describe("<AccordionPanel />", () => {
     });
   });
 
+  it("should allow an element for its title prop", () => {
+    const title = <p>accordion panel title</p>;
+    const { container } = render(
+      <Accordion>
+        <AccordionPanel
+          className={customPanelClassName}
+          controlId={controlId}
+          testMode
+          title={title}
+        >
+          content 1
+        </AccordionPanel>
+      </Accordion>,
+    );
+    const header = container
+      .getElementsByClassName("rvt-accordion__toggle-text")
+      .item(0);
+    const headerElement = header.getElementsByTagName("p").item(0);
+    expect(headerElement.innerHTML).toBe("accordion panel title");
+  });
+
   describe("Options", () => {
     it("default is test mode off", () => {
       render(

--- a/src/components/Accordion/AccordionPanel.jsx
+++ b/src/components/Accordion/AccordionPanel.jsx
@@ -8,7 +8,7 @@ import * as React from "react";
 import * as Rivet from "../util/Rivet";
 import { TestUtils } from "../util/TestUtils";
 
-const testIds = TestUtils.Accordion
+const testIds = TestUtils.Accordion;
 
 const AccordionPanel = ({
   children,
@@ -18,20 +18,17 @@ const AccordionPanel = ({
   title,
   ...attrs
 }) => {
-  const classNameArr = [
-    "rvt-accordion__panel",
-    className
-  ]
+  const classNameArr = ["rvt-accordion__panel", className];
   return (
     <div
       aria-labelledby={controlId}
       className={classNames(classNameArr)}
       {...(testMode && { "data-testid": `${testIds.panel}-${controlId}` })}
-      { ...attrs }
-      >
+      {...attrs}
+    >
       {children}
     </div>
-  )
+  );
 };
 
 AccordionPanel.displayName = "AccordionPanel";
@@ -39,7 +36,7 @@ AccordionPanel.propTypes = {
   /** [Developer] Adds data-testId attributes for component testing */
   testMode: PropTypes.bool,
   /** The panel's title */
-  title: PropTypes.string.isRequired
+  title: PropTypes.node.isRequired,
 };
 
 export default Rivet.rivetize(AccordionPanel);


### PR DESCRIPTION
This re-implements [the change](https://github.com/indiana-university/rivet-react/pull/538) to the `AccordionPanel` `title` prop and will use the correct commit type to trigger a release.