### PR TITLE
fix: Corrected trigger for mobile/collapsed nav menu

### DIFF
--- a/src/components/Header/HeaderNavigation.test.jsx
+++ b/src/components/Header/HeaderNavigation.test.jsx
@@ -113,21 +113,6 @@ describe("<HeaderNavigation />", () => {
       ).not.toHaveAttribute("hidden", "");
     });
 
-    it("should not hide the nav if the Tab key is pressed while the nav is open", async () => {
-      // open the nav
-      await toggleNavThroughClick();
-      // verify that the nav is opened
-      expect(
-        screen.getByTestId(TestUtils.Header.headerNavTestId),
-      ).not.toHaveAttribute("hidden", "");
-      // press Tab
-      await user.keyboard("{Tab}");
-      // finally, verify that the menu is not closed
-      expect(
-        screen.getByTestId(TestUtils.Header.headerNavTestId),
-      ).not.toHaveAttribute("hidden", "");
-    });
-
     it("should not hide the nav if an unhandled key is pressed while the menu is open", async () => {
       // open the nav
       await toggleNavThroughClick();

--- a/src/components/util/EventUtils.js
+++ b/src/components/util/EventUtils.js
@@ -3,6 +3,8 @@ Copyright (C) 2018 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
 */
 
+import { isEmpty } from "lodash";
+
 export const keys = {
   tab: "Tab",
   escape: "Escape",
@@ -57,8 +59,11 @@ export const targets = (container, event) =>
 const focusableElementList =
   'button, a[href], input[type="radio"]:checked, input:not([type="radio"]), select, textarea, [tabindex]:not([tabindex="-1"])';
 
-export function getFocusableElements(element) {
-  const focusable = element.querySelectorAll(focusableElementList);
+export function getFocusableElements(element, additionalFocusable = "") {
+  const focusEleList = isEmpty(additionalFocusable)
+    ? focusableElementList
+    : `${focusableElementList}, ${additionalFocusable}`;
+  const focusable = element.querySelectorAll(focusEleList);
   const focusableArray = Array.prototype.slice.call(focusable);
   const enabledFocusable = focusableArray.filter((el) => {
     return !el.disabled;


### PR DESCRIPTION
The issue was the check for should the menu toggle would detect the click as outside and close the menu immediately after open if the icon element in the button was clicked.   This is because the element contains method does not work with the icons due to render timing.  For this modified the setup of the menu to match the way the Header Menu works as it fixed the issue and added consistency in the menus.