### PR TITLE
fix: export typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
       "import": "./dist/rivet-react-pagenotfoundlayout.js",
       "require": "./dist/rivet-react-pagenotfoundlayout.cjs"
     },
-    "./Layouts/ServerErrorLayoput": {
+    "./Layouts/ServerErrorLayout": {
       "import": "./dist/rivet-react-servererrorlayout.js",
       "require": "./dist/rivet-react-servererrorlayout.cjs"
     },


### PR DESCRIPTION
There is a typo in the export for `ServerErrorLayout`.