### PR TITLE
feat: EPMDW-3979 - Use div tag for Alert body - closes #586

### DIFF
--- a/src/components/Alert/Alert.jsx
+++ b/src/components/Alert/Alert.jsx
@@ -71,7 +71,7 @@ const Alert = ({
       {...attrs}
     >
       {headerFragment()}
-      <p className="rvt-alert__message">{children}</p>
+      <div className="rvt-alert__message">{children}</div>
       {dismissFragment()}
     </div>
   ) : null;


### PR DESCRIPTION
The paragraph tag is problematic because block level items are not allowed under `p` tags.

I asked Levi McGranahan ([lmcgrana@iu.edu](mailto:lmcgrana@iu.edu)) about this and he indicated that switching to a `div` would be fine. 