### PR TITLE
ci: #573 use trusted publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,9 @@ jobs:
           command: npm run build
       - run:
           name: Publish package
-          command: npx semantic-release@25.0.3
+          command: |
+            export NPM_ID_TOKEN=$(circleci run oidc get --claims '{"aud": "npm:registry.npmjs.org"}')
+            npx semantic-release@25.0.3
 
 # Job orchestration
 workflows:


### PR DESCRIPTION
The `NPM_ID_TOKEN` is populated by generating a Trusted Publishing OIDC token from the `circleci` CLI via the npmjs.com connection. This feature is unavailable for forked builds.