### PR TITLE
ci: remove unneeded auth token

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,2 @@
 save-exact=true
 registry=https://registry.npmjs.org/
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
When using [semantic-release/npm](https://github.com/semantic-release/npm#npm-configuration) the `.nmprc` configuration which included the token from the environment is overriding the `NPM_ID_TOKEN` generated by CircleCI's trusted publishing.