### PR TITLE
ci: add readwrite deploy key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,9 @@ jobs:
   publish_guide:
     <<: *defaults
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:l04L5vc80Rdf3pXJ3un1pNrzSsHcgj7ja9b+pvLdzcg iubot@iu.edu"
       - checkout
       - restore_cache: *restore-node-modules
       - run:
@@ -68,6 +71,9 @@ jobs:
   publish_package:
     <<: *defaults
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:l04L5vc80Rdf3pXJ3un1pNrzSsHcgj7ja9b+pvLdzcg iubot@iu.edu"
       - checkout
       - restore_cache: *restore-node-modules
       - run:


### PR DESCRIPTION
Deploy keys generated by the CircleCI UI only have read access. I have created a deploy key and followed the [documentation](https://circleci.com/docs/guides/permissions-authentication/users-organizations-and-integrations-guide/) to add the deploy key to Circle CI and the public key to the repository. This change adds the fingerprint for CircleCI to use to override the default HTTPS connection used to checkout/push.