### PR TITLE
ci: use pinned semantic-release in workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -75,4 +75,4 @@ jobs:
           # No NPM_TOKEN: authentication uses npm Trusted Publishing (OIDC).
           # The id-token: write permission above lets semantic-release/npm
           # exchange the workflow's OIDC token for an npm publish credential.
-        run: npx semantic-release@25.0.3
+        run: npm exec semantic-release


### PR DESCRIPTION
Update the publish-package workflow to use the locally installed pinned semantic-release