### PR TITLE
ci: enable debug on semantic-release/npm

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -75,4 +75,4 @@ jobs:
           # No NPM_TOKEN: authentication uses npm Trusted Publishing (OIDC).
           # The id-token: write permission above lets semantic-release/npm
           # exchange the workflow's OIDC token for an npm publish credential.
-        run: npm exec semantic-release
+        run: DEBUG=semantic-release:npm* npm exec semantic-release


### PR DESCRIPTION
This is a temporary workaround to try to get a better error message than [error.errors is not iterable](https://github.com/semantic-release/npm/issues/1051)