### PR TITLE
fix: apply aria attributes to all dialogs

### DIFF
--- a/src/components/Dialog/Dialog.jsx
+++ b/src/components/Dialog/Dialog.jsx
@@ -33,7 +33,7 @@ const Dialog = ({
   isOpen,
   onDismiss,
   showCloseButton = true,
-  title,
+  title = "Dialog",
   ...attrs
 }) => {
   const ref = React.useRef(null);
@@ -137,7 +137,7 @@ const Dialog = ({
             // don't want the id from react-spectrum Dialog, use rivet format
             {...removeProperty(titleProps, "id")}
           >
-            {title || "Dialog"}
+            {title}
           </h1>
         </header>
         {children}

--- a/src/components/Dialog/Dialog.jsx
+++ b/src/components/Dialog/Dialog.jsx
@@ -119,6 +119,7 @@ const Dialog = ({
     >
       <div
         className={classNames("rvt-dialog", className)}
+        aria-labelledby={`${id}-title`}
         aria-hidden={!isOpen}
         hidden={!isOpen}
         ref={ref}
@@ -126,21 +127,19 @@ const Dialog = ({
         {...overlayProps}
         id={id}
       >
-        {title && (
-          <header
-            className="rvt-dialog__header"
-            data-testid={TestUtils.Dialog.dialogHeaderTestId}
+        <header
+          className="rvt-dialog__header"
+          data-testid={TestUtils.Dialog.dialogHeaderTestId}
+        >
+          <h1
+            className="rvt-dialog__title"
+            id={`${id}-title`}
+            // don't want the id from react-spectrum Dialog, use rivet format
+            {...removeProperty(titleProps, "id")}
           >
-            <h1
-              className="rvt-dialog__title"
-              id={`${id}-title`}
-              // don't want the id from react-spectrum Dialog, use rivet format
-              {...removeProperty(titleProps, "id")}
-            >
-              {title}
-            </h1>
-          </header>
-        )}
+            {title || "Dialog"}
+          </h1>
+        </header>
         {children}
         {onDismiss && showCloseButton && (
           <DialogCloseButton
@@ -217,7 +216,7 @@ Dialog.propTypes = {
   /** Whether or not to render a close button. Setting this value to true requires onDismiss to be passed */
   showCloseButton: PropTypes.bool,
   /** The content of the dialog's header */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
 };
 
 export default Rivet.rivetize(Dialog);

--- a/src/components/Dialog/Dialog.jsx
+++ b/src/components/Dialog/Dialog.jsx
@@ -217,7 +217,7 @@ Dialog.propTypes = {
   /** Whether or not to render a close button. Setting this value to true requires onDismiss to be passed */
   showCloseButton: PropTypes.bool,
   /** The content of the dialog's header */
-  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 };
 
 export default Rivet.rivetize(Dialog);

--- a/src/components/Dialog/Dialog.jsx
+++ b/src/components/Dialog/Dialog.jsx
@@ -158,6 +158,7 @@ const Dialog = ({
       return (
         <div
           role="dialog"
+          aria-labelledby={`${id}-title`}
           style={{
             position: "fixed",
             zIndex: 1000,

--- a/src/components/Header/BaseHeaderNavigation.jsx
+++ b/src/components/Header/BaseHeaderNavigation.jsx
@@ -4,17 +4,23 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 import * as React from "react";
 import PropTypes from "prop-types";
+import { v5 as uuidv5 } from "uuid";
 
 import * as Rivet from "../util/Rivet";
 import { useEffect, useRef } from "react";
 import Header from "./Header";
 import BaseHeaderMenuItem from "./BaseHeaderMenuItem";
+import HeaderAvatar from "./HeaderAvatar";
+import HeaderSearch from "./HeaderSearch";
 import { getFocusableElements, stillFocused } from "../util/EventUtils";
 import { TestUtils } from "../util/TestUtils";
 
 import "rivet-icons/dist/close.js";
 import "rivet-icons/dist/menu.js";
 import button from "../Button/Button.jsx";
+
+// This is a randomly generated UUID namespace so that we can create consistent keys for list item children
+const UUID_NAMESPACE = "f9e6c1d0-3b8a-4f5e-9c7a-2f3b1c6d7e8f";
 
 const BaseHeaderNavigation = ({ children, testMode = false, ...attrs }) => {
   const [isNavMenuOpen, setIsNavMenuOpen] = React.useState(false);
@@ -94,15 +100,28 @@ const BaseHeaderNavigation = ({ children, testMode = false, ...attrs }) => {
   // Avatar and Search components need to be rendered inside the nav tag, but outside of the list
   const listItems = [];
   const otherHeaderMenuItems = [];
-  React.Children.forEach(children, (child) => {
-    if (
-      child &&
-      ([BaseHeaderMenuItem, "li"].includes(child.type) ||
-        child.props.navlistitem)
-    ) {
-      listItems.push(child);
-    } else {
-      otherHeaderMenuItems.push(child);
+  React.Children.map(children, (child) => {
+    if (child) {
+      if (
+        [BaseHeaderMenuItem, "li"].includes(child.type) ||
+        (child.props["data-navlistitem"] ?? false) !== false
+      ) {
+        // We want to strip the invalid HTML attribute "data-navlistitem" from the list item, but we still want to use it to determine if the item should be rendered inside the list or not. So we destructure it out of the props and then spread the rest of the props into the cloned element.
+        const { "data-navlistItem": dataNavlistItem, ...rest } = child.props;
+        listItems.push(
+          React.cloneElement(child, {
+            key: uuidv5(JSON.stringify(rest), UUID_NAMESPACE),
+            ...rest,
+          }),
+        );
+      } else {
+        otherHeaderMenuItems.push(
+          React.cloneElement(child, {
+            key: uuidv5(JSON.stringify(child.props), UUID_NAMESPACE),
+            ...child.props,
+          }),
+        );
+      }
     }
   });
 
@@ -138,8 +157,10 @@ const BaseHeaderNavigation = ({ children, testMode = false, ...attrs }) => {
         ref={dropdownRef}
         data-testid={testMode ? TestUtils.Header.headerNavTestId : null}
       >
-        <ul className="rvt-header-menu__list">{listItems}</ul>
-        {otherHeaderMenuItems}
+        <ul className="rvt-header-menu__list">
+          {React.Children.toArray(listItems)}
+        </ul>
+        {React.Children.toArray(otherHeaderMenuItems)}
       </nav>
     </div>
   );
@@ -149,25 +170,15 @@ BaseHeaderNavigation.displayName = "BaseHeaderNavigation";
 /* istanbul ignore next */
 BaseHeaderNavigation.propTypes = {
   /** All children must be 'li', BaseHeaderMenuItem, Header.Avatar, or Header.Search */
-  children: (props, propName) => {
-    let propValue = props[propName];
-    const validChildren = [
+  children: PropTypes.shape({
+    type: PropTypes.oneOf([
       "li",
       BaseHeaderMenuItem,
-      Header.Avatar,
-      Header.Search,
-    ];
-    React.Children.forEach(propValue, (child) => {
-      if (
-        child &&
-        !(validChildren.includes(child.type) || child.props.navlistitem)
-      ) {
-        throw new Error(
-          `each child should be of type ${validChildren} or have navlistitem property set as true`,
-        );
-      }
-    });
-  },
+      HeaderAvatar,
+      HeaderSearch,
+    ]),
+    "data-navlistitem": PropTypes.bool,
+  }),
   /** [Developer] Adds data-testId attributes for component testing */
   testMode: PropTypes.bool,
 };

--- a/src/components/Header/BaseHeaderNavigation.md
+++ b/src/components/Header/BaseHeaderNavigation.md
@@ -1,8 +1,8 @@
 Base header components focus on letting users directly build the html element. They are less restrictive on allowed properties and components but also do not modify/process them.
 Other versions of header components utilizes the base components while adding a specific structure.
 
-This BaseHeaderNavigation sets any list item children elements in the menu list while other elements are placed 
-after the list. Components can be manually added to the list using the `navListItem` property on them. This should only
+This BaseHeaderNavigation sets any list item children elements in the menu list while other elements are placed
+after the list. Components can be manually added to the list using the `data-navListItem` property on them. This should only
 be done for custom components whose outer element is `li` to maintain well-formed html.
 
 <!-- prettier-ignore-start -->

--- a/src/components/Header/BaseHeaderNavigation.test.jsx
+++ b/src/components/Header/BaseHeaderNavigation.test.jsx
@@ -397,7 +397,7 @@ describe("<BaseHeaderNavigation />", () => {
         <BaseHeaderNavigation testMode>
           <BaseHeaderMenuItem>Nav item one</BaseHeaderMenuItem>
           <li>Nav item two</li>
-          <div navlistitem>Nav item three</div>
+          <div navlistitem="true">Nav item three</div>
         </BaseHeaderNavigation>,
       );
       const element = screen.queryByTestId(testIds.headerNavTestId);

--- a/src/components/Header/BaseHeaderNavigation.test.jsx
+++ b/src/components/Header/BaseHeaderNavigation.test.jsx
@@ -392,12 +392,12 @@ describe("<BaseHeaderNavigation />", () => {
       expect(component.nodeName).toBe("DIV");
       expect(component.innerHTML).toBe("Nav item three");
     });
-    it("if marked with navlistitem item should render inside list", () => {
+    it("if marked with 'data-navlistitem' item should render inside list", () => {
       render(
         <BaseHeaderNavigation testMode>
           <BaseHeaderMenuItem>Nav item one</BaseHeaderMenuItem>
           <li>Nav item two</li>
-          <div navlistitem="true">Nav item three</div>
+          <div data-navlistitem="true">Nav item three</div>
         </BaseHeaderNavigation>,
       );
       const element = screen.queryByTestId(testIds.headerNavTestId);


### PR DESCRIPTION
Require a title for all dialog components (since they are required for accessibility) and properly populate `aria-labelledby` attributes for the surrounding div.

Additionally another test was throwing a warning that `div` cannot accept Javascript boolean attributes the way a React component can.

Closes #630